### PR TITLE
feat(insight-module): add AsyncListenerAdapter interface

### DIFF
--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/support/adapter/AsyncListenerAdapter.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/support/adapter/AsyncListenerAdapter.java
@@ -1,0 +1,20 @@
+package com.sdlcpro.springlens.insight.support.adapter;
+
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+
+import java.io.IOException;
+
+public interface AsyncListenerAdapter extends AsyncListener {
+    default void onComplete(AsyncEvent var1) throws IOException {
+    }
+
+    default void onTimeout(AsyncEvent var1) throws IOException {
+    }
+
+    default void onError(AsyncEvent var1) throws IOException {
+    }
+
+    default void onStartAsync(AsyncEvent var1) throws IOException {
+    }
+}


### PR DESCRIPTION
Adds the AsyncListenerAdapter interface inside the `com.sdlcpro.springlens.insight.support.adapter` package.

This provides empty default implementations for all four AsyncListener lifecycle methods, reducing boilerplate for callers that only need to handle specific events.

Fixes #56