### PR TITLE
feat(annotation): add SpringLensInternalComponent marker annotation

### DIFF
--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/annotation/SpringLenInternalComponent.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/annotation/SpringLenInternalComponent.java
@@ -1,0 +1,14 @@
+package com.sdlcpro.springlens.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation used to identify internal SpringLens components.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SpringLenInternalComponent {
+}


### PR DESCRIPTION

## Description

This PR introduces the `SpringLensInternalComponent` marker annotation to explicitly identify internal SpringLens components. The annotation is retained at runtime and restricted to type declarations, enabling future support for component scanning, custom bean processing, and architectural boundary enforcement.

## Related Issue

Closes #71

## Type of Change

- [x] Feature

## Changes

- Added the `SpringLensInternalComponent` marker annotation.
- Restricted the annotation to type declarations using `@Target(ElementType.TYPE)`.
- Configured runtime retention using `@Retention(RetentionPolicy.RUNTIME)`.
- Added Javadoc describing the purpose of the annotation.

## Verification

- Verified the annotation is created in the `com.sdlcpro.springlens.annotation` package.
- Verified the `@Target(ElementType.TYPE)` and `@Retention(RetentionPolicy.RUNTIME)` meta-annotations are correctly configured.
- Confirmed the project builds successfully.

