### PR TITLE
Add BeanInstanceInfoRepository for bean instance data access

### DIFF
--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/repository/bean/instance/BeanInstanceInfoRepository.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/repository/bean/instance/BeanInstanceInfoRepository.java
@@ -1,0 +1,20 @@
+package com.sdlcpro.springlens.repository.bean.instance;
+
+import com.sdlcpro.springlens.model.bean.BeanInfoCompositeKey;
+import com.sdlcpro.springlens.model.bean.instance.BeanInstanceInfo;
+import com.sdlcpro.springlens.model.bean.instance.BeanInstanceProxyInfo;
+import com.sdlcpro.springlens.repository.PageableRepository;
+
+/**
+ * Manages persistence for {@link BeanInstanceInfo}, by context ID and bean name.
+ */
+public interface BeanInstanceInfoRepository extends PageableRepository<BeanInstanceInfo, BeanInfoCompositeKey> {
+
+    /**
+     * Returns proxy metadata for the bean instance matching the given key.
+     *
+     * @param key context ID + bean name identifying the instance
+     * @return proxy info, or null if no matching instance exists
+     */
+    BeanInstanceProxyInfo findProxyInfoById(BeanInfoCompositeKey key);
+}


### PR DESCRIPTION
Implements BeanInstanceInfoRepository extending PageableRepository, with findProxyInfoById for fetching proxy metadata.

Closes #97