### PR TITLE
Enhancement:Web Tier Global Response Infrastructure

### DIFF
--- a/spring-lens-exposure-http/src/main/java/com/sdlcpro/springlens/exposure/ApiErrorResponse.java
+++ b/spring-lens-exposure-http/src/main/java/com/sdlcpro/springlens/exposure/ApiErrorResponse.java
@@ -1,0 +1,9 @@
+package com.sdlcpro.springlens.exposure;
+
+import java.time.Instant;
+
+public record ApiErrorResponse(
+    Instant timestamp,
+    int status,
+    String error,
+    String message ){}

--- a/spring-lens-exposure-http/src/main/java/com/sdlcpro/springlens/exposure/ApiResponseHandler.java
+++ b/spring-lens-exposure-http/src/main/java/com/sdlcpro/springlens/exposure/ApiResponseHandler.java
@@ -1,0 +1,41 @@
+package com.sdlcpro.springlens.exposure;
+
+import com.sdlcpro.springlens.exception.DataNotFoundException;
+import com.sdlcpro.springlens.exception.DataScopeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.function.Supplier;
+
+public final class ApiResponseHandler {
+
+    private ApiResponseHandler(){
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    public static ResponseEntity<?> handle(Supplier<?> dataFetchLogicSupplier){
+        String message;
+        HttpStatus status;
+
+        try{
+            return ResponseEntity.ok(dataFetchLogicSupplier.get());
+        } catch (Exception e){
+            message = e.getMessage();
+            if (e instanceof DataScopeMismatchException || e instanceof IllegalArgumentException) {
+                status = HttpStatus.BAD_REQUEST;
+            } else if(e instanceof DataNotFoundException) {
+                status = HttpStatus.NOT_FOUND;
+            } else {
+                status = HttpStatus.INTERNAL_SERVER_ERROR;
+            }
+        }
+        var errorResponse = new ApiErrorResponse(
+                Instant.now(),
+                status.value(),
+                status.getReasonPhrase(),
+                message
+        );
+        return ResponseEntity.status(status).body(errorResponse);
+    }
+}

--- a/spring-lens-exposure-http/src/test/java/com/sdlcpro/springlens/exposure/ApiResponseHandlerTest.java
+++ b/spring-lens-exposure-http/src/test/java/com/sdlcpro/springlens/exposure/ApiResponseHandlerTest.java
@@ -1,0 +1,84 @@
+package com.sdlcpro.springlens.exposure;
+
+import com.sdlcpro.springlens.exception.DataNotFoundException;
+import com.sdlcpro.springlens.exception.DataScopeMismatchException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApiResponseHandlerTest {
+
+    @Test
+    void shouldReturnOkResponseForSuccessfulSupplier() {
+        ResponseEntity<?> response = ApiResponseHandler.handle(() -> "Success");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Success", response.getBody());
+    }
+
+    @Test
+    void shouldReturnNotFoundForDataNotFoundException() {
+        ResponseEntity<?> response = ApiResponseHandler.handle(() -> {
+            throw new DataNotFoundException("Metadata not found");
+        });
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+
+        ApiErrorResponse body = (ApiErrorResponse) response.getBody();
+        assertNotNull(body);
+        assertEquals(404, body.status());
+        assertEquals("Not Found", body.error());
+        assertEquals("Metadata not found", body.message());
+        assertNotNull(body.timestamp());
+    }
+
+    @Test
+    void shouldReturnBadRequestForDataScopeMismatchException() {
+        ResponseEntity<?> response = ApiResponseHandler.handle(() -> {
+            throw new DataScopeMismatchException("Scope mismatch");
+        });
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+        ApiErrorResponse body = (ApiErrorResponse) response.getBody();
+        assertNotNull(body);
+        assertEquals(400, body.status());
+        assertEquals("Bad Request", body.error());
+        assertEquals("Scope mismatch", body.message());
+        assertNotNull(body.timestamp());
+    }
+
+    @Test
+    void shouldReturnBadRequestForIllegalArgumentException() {
+        ResponseEntity<?> response = ApiResponseHandler.handle(() -> {
+            throw new IllegalArgumentException("Invalid argument");
+        });
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+        ApiErrorResponse body = (ApiErrorResponse) response.getBody();
+        assertNotNull(body);
+        assertEquals(400, body.status());
+        assertEquals("Bad Request", body.error());
+        assertEquals("Invalid argument", body.message());
+        assertNotNull(body.timestamp());
+    }
+
+    @Test
+    void shouldReturnInternalServerErrorForUnexpectedException() {
+        ResponseEntity<?> response = ApiResponseHandler.handle(() -> {
+            throw new RuntimeException("Unexpected error");
+        });
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+
+        ApiErrorResponse body = (ApiErrorResponse) response.getBody();
+        assertNotNull(body);
+        assertEquals(500, body.status());
+        assertEquals("Internal Server Error", body.error());
+        assertEquals("Unexpected error", body.message());
+        assertNotNull(body.timestamp());
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Introduces a standardized API error response model and a centralized response handler for HTTP exposure.

### Changes
- Added `ApiErrorResponse` as an immutable record for consistent error payloads.
- Added `ApiResponseHandler` utility class to translate application exceptions into appropriate HTTP responses.
- Mapped:
  - `DataNotFoundException` → `404 Not Found`
  - `DataScopeMismatchException` → `400 Bad Request`
  - `IllegalArgumentException` → `400 Bad Request`
  - Other exceptions → `500 Internal Server Error`
- Added unit tests covering successful responses and all supported exception mappings.

## Related issue

Closes #112 

## How was this tested?

- [x] Verified successful supplier returns `200 OK`.
- [x] Verified `DataNotFoundException` returns `404 Not Found`.
- [x] Verified `DataScopeMismatchException` returns `400 Bad Request`.
- [x] Verified `IllegalArgumentException` returns `400 Bad Request`.
- [x] Verified unexpected exceptions return `500 Internal Server Error`.

## Checklist

- [x] I have added/updated tests for the new behavior.
- [x] The implementation follows the project's existing coding conventions.