### PR TITLE
feat: introduce @SpringLensEndpoint marker annotation 

### DIFF
--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/annotation/SpringLensEndpoint.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/annotation/SpringLensEndpoint.java
@@ -1,0 +1,19 @@
+package com.sdlcpro.springlens.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation used to explicitly flag internal HTTP endpoints belonging to the Spring Lens framework.
+ *  <p>When applied to a Controller type or a specific route method, it instructs the framework
+ * to bypass this endpoint when collecting performance data for the user's metrics.
+ * This ensures that internal framework requests (such as UI dashboard rendering or
+ * lifecycle health checks) are not recorded.</p>
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SpringLensEndpoint {
+}


### PR DESCRIPTION
### Description
This PR introduces the `@SpringLensEndpoint` marker annotation to explicitly flag internal HTTP controller types, specific route methods, or lifecycle diagnostic dashboard endpoints. By marking these internal framework endpoints, the core monitoring engine can bypass them during performance data collection, ensuring that the user's application metrics are not skewed or polluted by internal framework traffic (such as UI rendering or background health checks).

### Changes
- Created the `@SpringLensEndpoint` marker annotation restricted to `TYPE` and `METHOD` targets.
- Set retention policy to `RUNTIME` to allow dynamic analysis by the Spring Boot infrastructure.
- Added comprehensive Javadoc documentation explaining its purpose and benefits.

### Related Issues
Closes #123