### PR TITLE
Fix/#155 #169 headers

### DIFF
--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/HttpResponseStatus.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/HttpResponseStatus.java
@@ -1,0 +1,123 @@
+package com.sdlcpro.springlens.model.http;
+
+/**
+ * Represents the HTTP response status codes recognized by Spring Lens.
+ * <p>
+ * This enumeration provides a type-safe representation of standard HTTP
+ * response status codes captured at the interceptor filter layer. Lookups
+ * by numeric code are resolved in constant time: valid codes are pre-indexed
+ * into a fixed-size array during class initialization, avoiding both
+ * repeated {@code values()} array cloning and any per-call linear scan.
+ * Unknown or unsupported status codes are safely mapped to {@link #UNKNOWN}.
+ */
+public enum HttpResponseStatus {
+
+    UNKNOWN(-1),
+
+    CONTINUE(100),
+    SWITCHING_PROTOCOLS(101),
+    PROCESSING(102),
+
+    OK(200),
+    CREATED(201),
+    ACCEPTED(202),
+    NON_AUTHORITATIVE_INFORMATION(203),
+    NO_CONTENT(204),
+    RESET_CONTENT(205),
+    PARTIAL_CONTENT(206),
+
+    MULTIPLE_CHOICES(300),
+    MOVED_PERMANENTLY(301),
+    FOUND(302),
+    SEE_OTHER(303),
+    NOT_MODIFIED(304),
+    TEMPORARY_REDIRECT(307),
+    PERMANENT_REDIRECT(308),
+
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    PAYMENT_REQUIRED(402),
+    FORBIDDEN(403),
+    NOT_FOUND(404),
+    METHOD_NOT_ALLOWED(405),
+    NOT_ACCEPTABLE(406),
+    PROXY_AUTHENTICATION_REQUIRED(407),
+    REQUEST_TIMEOUT(408),
+    CONFLICT(409),
+    GONE(410),
+    LENGTH_REQUIRED(411),
+    PRECONDITION_FAILED(412),
+    PAYLOAD_TOO_LARGE(413),
+    URI_TOO_LONG(414),
+    UNSUPPORTED_MEDIA_TYPE(415),
+    EXPECTATION_FAILED(417),
+    UNPROCESSABLE_ENTITY(422),
+    TOO_EARLY(425),
+    UPGRADE_REQUIRED(426),
+    PRECONDITION_REQUIRED(428),
+    TOO_MANY_REQUESTS(429),
+    REQUEST_HEADER_FIELDS_TOO_LARGE(431),
+    UNAVAILABLE_FOR_LEGAL_REASONS(451),
+
+    INTERNAL_SERVER_ERROR(500),
+    NOT_IMPLEMENTED(501),
+    BAD_GATEWAY(502),
+    SERVICE_UNAVAILABLE(503),
+    GATEWAY_TIMEOUT(504),
+    HTTP_VERSION_NOT_SUPPORTED(505),
+    INSUFFICIENT_STORAGE(507),
+    LOOP_DETECTED(508),
+    NOT_EXTENDED(510),
+    NETWORK_AUTHENTICATION_REQUIRED(511);
+
+    private static final int MAX_CODE = 511;
+
+    private static final HttpResponseStatus[] BY_CODE;
+
+    static {
+        BY_CODE = new HttpResponseStatus[MAX_CODE + 1];
+        for (HttpResponseStatus status : values()) {
+            if (status.code >= 0 && status.code <= MAX_CODE) {
+                BY_CODE[status.code] = status;
+            }
+        }
+    }
+
+    private final int code;
+
+    HttpResponseStatus(int code) {
+        this.code = code;
+    }
+
+    /**
+     * Returns the corresponding {@code HttpResponseStatus} for the supplied
+     * numeric status code.
+     * <p>
+     * Resolution is performed in constant time via a pre-built lookup array,
+     * with an early range check ({@code code < 0 || code > 511}) so that
+     * out-of-range values fast-fail to {@link #UNKNOWN} without touching the
+     * array. If the supplied code falls within range but has no mapped
+     * constant, {@link #UNKNOWN} is also returned.
+     *
+     * @param code the HTTP response status code to resolve
+     * @return the matching {@code HttpResponseStatus}, or {@link #UNKNOWN}
+     * if no match exists
+     */
+    public static HttpResponseStatus from(int code) {
+        if (code < 0 || code > MAX_CODE) {
+            return UNKNOWN;
+        }
+
+        HttpResponseStatus status = BY_CODE[code];
+        return status != null ? status : UNKNOWN;
+    }
+
+    /**
+     * Returns the numeric HTTP response status code.
+     *
+     * @return the status code
+     */
+    public int getCode() {
+        return this.code;
+    }
+}

--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/request/Header.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/request/Header.java
@@ -1,0 +1,23 @@
+package com.sdlcpro.springlens.model.http.request;
+
+import com.sdlcpro.springlens.util.Preconditions;
+
+import java.util.List;
+
+/**
+ * Represents a single HTTP header entry captured during request/response
+ * interception, preserving its canonical name and all associated values.
+ */
+public record Header(String name, List<String> values) {
+
+    public Header {
+        Preconditions.hasText(name, "Header name must not be blank");
+
+        if (values != null) {
+            Preconditions.noNullElements(values, "Header values must not contain null elements");
+            values = List.copyOf(values);
+        } else {
+            values = List.of();
+        }
+    }
+}

--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/request/HttpRequestData.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/request/HttpRequestData.java
@@ -1,0 +1,69 @@
+package com.sdlcpro.springlens.model.http.request;
+
+import com.sdlcpro.springlens.model.http.HttpRequestMethod;
+import com.sdlcpro.springlens.util.Preconditions;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Immutable snapshot of an inbound HTTP request captured at the
+ * interceptor boundary, used as the source data for trace recording.
+ * <p>
+ * Multi-value query parameter arrays are defensively copied both at
+ * construction time and on every read via {@link #parameters()}, so that
+ * neither the caller supplying the original map nor a caller mutating the
+ * returned map's array values can affect this record's internal state.
+ */
+public record HttpRequestData(
+        HttpRequestMethod method,
+        String uri,
+        Map<String, String[]> parameters,
+        String protocol,
+        String contentType,
+        int contentSize,
+        String clientIpAddress,
+        List<Header> requestHeaders,
+        String requestBody) {
+
+    public HttpRequestData {
+        Preconditions.notNull(method, "HttpRequestMethod must not be null");
+        Preconditions.notNull(uri, "URI must not be null");
+        Preconditions.notNull(protocol, "Protocol must not be null");
+
+        parameters = cloneParameters(parameters);
+        requestHeaders = requestHeaders == null ? List.of() : List.copyOf(requestHeaders);
+    }
+
+    @Override
+    public Map<String, String[]> parameters() {
+        return cloneParameters(parameters);
+    }
+
+    private static Map<String, String[]> cloneParameters(Map<String, String[]> source) {
+        if (source == null) {
+            return Map.of();
+        }
+        return Map.copyOf(source.entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue() == null ? new String[0] : entry.getValue().clone())));
+    }
+
+    /**
+     * Determines whether the captured request body was truncated relative
+     * to the declared content size, e.g. when the interceptor stopped
+     * reading before the full payload arrived.
+     *
+     * @return {@code true} if fewer bytes were captured than declared
+     */
+    public boolean isBodyTruncated() {
+        if (this.requestBody == null) {
+            return this.contentSize > 0;
+        }
+
+        int byteBodyLength = this.requestBody.getBytes(StandardCharsets.UTF_8).length;
+        return byteBodyLength < this.contentSize;
+    }
+}

--- a/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/HttpResponseStatusTest.java
+++ b/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/HttpResponseStatusTest.java
@@ -1,0 +1,36 @@
+package com.sdlcpro.springlens.model.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpResponseStatusTest {
+
+    @Test
+    void resolvesKnownStatusCode() {
+        assertThat(HttpResponseStatus.from(200)).isEqualTo(HttpResponseStatus.OK);
+        assertThat(HttpResponseStatus.from(404)).isEqualTo(HttpResponseStatus.NOT_FOUND);
+        assertThat(HttpResponseStatus.from(500)).isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    void returnsUnknownForNegativeCode() {
+        assertThat(HttpResponseStatus.from(-15)).isEqualTo(HttpResponseStatus.UNKNOWN);
+    }
+
+    @Test
+    void returnsUnknownForCodeAboveUpperBound() {
+        assertThat(HttpResponseStatus.from(600)).isEqualTo(HttpResponseStatus.UNKNOWN);
+    }
+
+    @Test
+    void returnsUnknownForInRangeButUnmappedCode() {
+        assertThat(HttpResponseStatus.from(199)).isEqualTo(HttpResponseStatus.UNKNOWN);
+    }
+
+    @Test
+    void getCodeReturnsUnderlyingValue() {
+        assertThat(HttpResponseStatus.OK.getCode()).isEqualTo(200);
+        assertThat(HttpResponseStatus.UNKNOWN.getCode()).isEqualTo(-1);
+    }
+}

--- a/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/request/HeaderTest.java
+++ b/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/request/HeaderTest.java
@@ -1,0 +1,55 @@
+package com.sdlcpro.springlens.model.http.request;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeaderTest {
+
+    @Test
+    @DisplayName("should store name and values correctly")
+    void storesNameAndValues() {
+        Header header = new Header("Content-Type", List.of("application/json"));
+        assertEquals("Content-Type", header.name());
+        assertEquals(List.of("application/json"), header.values());
+    }
+
+    @Test
+    @DisplayName("should default null values to an empty list")
+    void defaultsNullValuesToEmptyList() {
+        Header header = new Header("X-Custom", null);
+        assertTrue(header.values().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should reject blank header name")
+    void rejectsBlankName() {
+        assertThrows(IllegalArgumentException.class, () -> new Header("  ", List.of("value")));
+    }
+
+    @Test
+    @DisplayName("should reject null header name")
+    void rejectsNullName() {
+        assertThrows(IllegalArgumentException.class, () -> new Header(null, List.of("value")));
+    }
+
+    @Test
+    @DisplayName("should reject values list containing null elements")
+    void rejectsNullElementInValues() {
+        List<String> values = new ArrayList<>();
+        values.add("application/json");
+        values.add(null);
+        assertThrows(IllegalArgumentException.class, () -> new Header("Accept", values));
+    }
+
+    @Test
+    @DisplayName("values list should be immutable")
+    void valuesListIsImmutable() {
+        Header header = new Header("Accept", List.of("application/json"));
+        assertThrows(UnsupportedOperationException.class, () -> header.values().add("text/html"));
+    }
+}

--- a/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/request/HttpRequestDataTest.java
+++ b/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/request/HttpRequestDataTest.java
@@ -1,0 +1,87 @@
+package com.sdlcpro.springlens.model.http.request;
+
+import com.sdlcpro.springlens.model.http.HttpRequestMethod;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpRequestDataTest {
+
+    private HttpRequestData sample(Map<String, String[]> parameters, String requestBody, int contentSize) {
+        return new HttpRequestData(
+                HttpRequestMethod.GET,
+                "/api/orders",
+                parameters,
+                "HTTP/1.1",
+                "application/json",
+                contentSize,
+                "127.0.0.1",
+                List.of(new Header("Content-Type", List.of("application/json"))),
+                requestBody);
+    }
+
+    @Test
+    @DisplayName("should reject null method, uri, or protocol")
+    void rejectsNullRequiredFields() {
+        assertThrows(IllegalArgumentException.class, () -> new HttpRequestData(null, "/x", Map.of(), "HTTP/1.1",
+                "text/plain", 0, "127.0.0.1", List.of(), null));
+        assertThrows(IllegalArgumentException.class, () -> new HttpRequestData(HttpRequestMethod.GET, null, Map.of(),
+                "HTTP/1.1", "text/plain", 0, "127.0.0.1", List.of(), null));
+        assertThrows(IllegalArgumentException.class, () -> new HttpRequestData(HttpRequestMethod.GET, "/x", Map.of(),
+                null, "text/plain", 0, "127.0.0.1", List.of(), null));
+    }
+
+    @Test
+    @DisplayName("should not be affected by mutating the original parameters map after construction")
+    void isNotAffectedByMutatingOriginalMapAfterConstruction() {
+        Map<String, String[]> original = new HashMap<>();
+        original.put("page", new String[] { "1" });
+
+        HttpRequestData data = sample(original, null, 0);
+        original.get("page")[0] = "999";
+        original.put("extra", new String[] { "leaked" });
+
+        assertEquals("1", data.parameters().get("page")[0]);
+        assertFalse(data.parameters().containsKey("extra"));
+    }
+
+    @Test
+    @DisplayName("should not expose internal state through the returned parameters map")
+    void doesNotExposeInternalStateThroughAccessor() {
+        Map<String, String[]> original = Map.of("page", new String[] { "1" });
+        HttpRequestData data = sample(original, null, 0);
+
+        data.parameters().get("page")[0] = "mutated";
+
+        assertEquals("1", data.parameters().get("page")[0]);
+    }
+
+    @Test
+    @DisplayName("should flag body as truncated when captured bytes are fewer than declared content size")
+    void flagsTruncatedBody() {
+        HttpRequestData data = sample(Map.of(), "partial", 100);
+        assertTrue(data.isBodyTruncated());
+    }
+
+    @Test
+    @DisplayName("should not flag body as truncated when full content was captured")
+    void doesNotFlagCompleteBody() {
+        String body = "{\"ok\":true}";
+        int size = body.getBytes(StandardCharsets.UTF_8).length;
+        HttpRequestData data = sample(Map.of(), body, size);
+        assertFalse(data.isBodyTruncated());
+    }
+
+    @Test
+    @DisplayName("should flag body as truncated when body is null but content size is positive")
+    void flagsTruncatedWhenBodyNullAndContentSizePositive() {
+        HttpRequestData data = sample(Map.of(), null, 50);
+        assertTrue(data.isBodyTruncated());
+    }
+}


### PR DESCRIPTION
Implements both Header (#155) and HttpRequestData (#169) together, since HttpRequestData depends on Header.

Header (#155):
- Implemented as specified.
- Fixed a bug in the proposed constructor: noNullElements was called unconditionally, but it internally rejects null before the intended "null defaults to empty list" logic could run. Now the null check only runs when values is non-null.

HttpRequestData (#169):
- Implemented as specified, including isBodyTruncated().
- Added a defensive copy on the parameters() accessor itself, not just in the constructor. Without it, callers could mutate the returned array and corrupt the record's internal state after construction.

Tests added for both records, covering validation, immutability, and the truncation logic.

Closes #155
Closes #169