### PR TITLE
feat(insight): implement InfraBeanRoleMatcher for ROLE_INFRASTRUCTURE filtering (#146)

### DIFF
--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/InfraBeanRoleMatcher.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/InfraBeanRoleMatcher.java
@@ -1,0 +1,39 @@
+package com.sdlcpro.springlens.insight.bean;
+
+import com.sdlcpro.springlens.insight.support.matcher.BeanRoleMatcher;
+import com.sdlcpro.springlens.model.bean.BeanRole;
+
+import java.util.EnumSet;
+
+/**
+ * A specialized, type-safe {@link BeanRoleMatcher} that isolates and identifies
+ * Spring internal components classified under the
+ * {@link BeanRole#ROLE_INFRASTRUCTURE ROLE_INFRASTRUCTURE} profile.
+ *
+ * <p>This matcher hardcodes the infrastructure role boundary into an immutable,
+ * single-element {@link EnumSet}, removing the need for client engines to pass
+ * enum arrays on every lifecycle lookup. As a result, role tracking routines
+ * across the metadata processing layer are simplified while remaining strictly
+ * aligned with structures capable of exposing their operational taxonomy through
+ * {@link BeanRoleProvider}.</p>
+ *
+ * <p>The class is declared {@code final} to close the extension branch: the
+ * infrastructure-only classification is intentional and immutable, and no further
+ * specialization is expected.</p>
+ *
+ * @param <T> the type of context being matched; must be capable of exposing its
+ *            {@link BeanRole} via {@link BeanRoleProvider}
+ * @since 1.0.0
+ * @see BeanRoleMatcher
+ * @see BeanRole#ROLE_INFRASTRUCTURE
+ */
+public final class InfraBeanRoleMatcher<T extends BeanRoleProvider> extends BeanRoleMatcher<T> {
+
+    /**
+     * Creates a matcher that accepts only contexts reporting the
+     * {@link BeanRole#ROLE_INFRASTRUCTURE} role.
+     */
+    public InfraBeanRoleMatcher() {
+        super(EnumSet.of(BeanRole.ROLE_INFRASTRUCTURE));
+    }
+}

--- a/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/bean/InfraBeanRoleMatcherTest.java
+++ b/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/bean/InfraBeanRoleMatcherTest.java
@@ -1,0 +1,44 @@
+package com.sdlcpro.springlens.insight.bean;
+
+import com.sdlcpro.springlens.model.bean.BeanRole;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InfraBeanRoleMatcherTest {
+
+    private final InfraBeanRoleMatcher<BeanRoleProvider> matcher = new InfraBeanRoleMatcher<>();
+
+    @Test
+    void matchesContextWithInfrastructureRole() {
+        BeanRoleProvider context = () -> BeanRole.ROLE_INFRASTRUCTURE;
+
+        assertThat(matcher.matches(context)).isTrue();
+    }
+
+    @Test
+    void doesNotMatchContextWithApplicationRole() {
+        BeanRoleProvider context = () -> BeanRole.ROLE_APPLICATION;
+
+        assertThat(matcher.matches(context)).isFalse();
+    }
+
+    @Test
+    void doesNotMatchContextWithSupportRole() {
+        BeanRoleProvider context = () -> BeanRole.ROLE_SUPPORT;
+
+        assertThat(matcher.matches(context)).isFalse();
+    }
+
+    @Test
+    void doesNotMatchContextWithUnknownRole() {
+        BeanRoleProvider context = () -> BeanRole.UNKNOWN;
+
+        assertThat(matcher.matches(context)).isFalse();
+    }
+
+    @Test
+    void doesNotMatchNullContext() {
+        assertThat(matcher.matches(null)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
Implements `InfraBeanRoleMatcher<T>`, a type-safe specialized matcher that isolates
Spring internal components classified under `BeanRole.ROLE_INFRASTRUCTURE`.

Closes #146

## Changes
- Add `InfraBeanRoleMatcher<T extends BeanRoleProvider>` in
  `com.sdlcpro.springlens.insight.bean` (module: `spring-lens-insight`).
- Class is `public final`; default constructor delegates to
  `super(EnumSet.of(BeanRole.ROLE_INFRASTRUCTURE))`, hardcoding the infrastructure
  boundary into an immutable single-element `EnumSet`.
- Add full JavaDoc for the class and constructor.
- Add `InfraBeanRoleMatcherTest` covering the truth table.

## Definition of Done
- [x] `InfraBeanRoleMatcher.java` created in `com.sdlcpro.springlens.insight.bean`
- [x] Declared `final` with `<T extends BeanRoleProvider>` bound
- [x] Constructor uses `EnumSet.of(BeanRole.ROLE_INFRASTRUCTURE)`
- [x] Unit tests for INFRASTRUCTURE (match) vs APPLICATION/SUPPORT/UNKNOWN/null (no match)
- [x] Proper JavaDoc

## Testing
- `spring-lens-insight` module: **95 tests pass** (including 5 new tests).
- New tests: matches `ROLE_INFRASTRUCTURE`; rejects `ROLE_APPLICATION`,
  `ROLE_SUPPORT`, `UNKNOWN`, and `null`.