### PR TITLE
feat(exposure-http): auto-configure BeanDetailsRestController for web apps (#16)

### DIFF
--- a/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/bean/BeanWebConfiguration.java
+++ b/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/bean/BeanWebConfiguration.java
@@ -1,0 +1,27 @@
+package com.sdlcpro.springlens.autoconfigure.bean;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.exposure.bean.BeanDetailsRestController;
+import com.sdlcpro.springlens.repository.bean.BeanDefinitionInfoRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.context.annotation.Bean;
+
+
+@SpringLensInternalComponent
+@ConditionalOnWebApplication(type = Type.SERVLET)
+public class BeanWebConfiguration {
+
+    /**
+     * Registers the REST controller that exposes paginated bean metadata.
+     *
+     * @param springLensBeanDefinitionInfoRepository the repository holding the collected
+     *                                               bean metadata
+     * @return the configured {@link BeanDetailsRestController} bean
+     */
+    @Bean("springLensBeanDetailsRestController")
+    public BeanDetailsRestController beanDetailsRestController(
+            BeanDefinitionInfoRepository springLensBeanDefinitionInfoRepository) {
+        return new BeanDetailsRestController(springLensBeanDefinitionInfoRepository);
+    }
+}

--- a/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/bean/BeanWebConfigurationTest.java
+++ b/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/bean/BeanWebConfigurationTest.java
@@ -1,0 +1,48 @@
+package com.sdlcpro.springlens.autoconfigure.bean;
+
+import com.sdlcpro.springlens.exposure.bean.BeanDetailsRestController;
+import com.sdlcpro.springlens.repository.bean.BeanDefinitionInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class BeanWebConfigurationTest {
+
+    private static final String CONTROLLER_BEAN_NAME = "springLensBeanDetailsRestController";
+
+    private final WebApplicationContextRunner webContextRunner = new WebApplicationContextRunner()
+            .withBean(BeanDefinitionInfoRepository.class, () -> mock(BeanDefinitionInfoRepository.class))
+            .withUserConfiguration(BeanWebConfiguration.class);
+
+    private final ApplicationContextRunner nonWebContextRunner = new ApplicationContextRunner()
+            .withBean(BeanDefinitionInfoRepository.class, () -> mock(BeanDefinitionInfoRepository.class))
+            .withUserConfiguration(BeanWebConfiguration.class);
+
+    @Test
+    void registersRestControllerInServletWebApplication() {
+        webContextRunner.run(context -> {
+            assertThat(context).hasBean(CONTROLLER_BEAN_NAME);
+            assertThat(context.getBean(CONTROLLER_BEAN_NAME))
+                    .isInstanceOf(BeanDetailsRestController.class);
+        });
+    }
+
+    @Test
+    void doesNotRegisterRestControllerInNonWebApplication() {
+        nonWebContextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(CONTROLLER_BEAN_NAME);
+            assertThat(context).doesNotHaveBean(BeanDetailsRestController.class);
+        });
+    }
+
+    @Test
+    void wiresRestControllerToRepository() {
+        webContextRunner.run(context -> {
+            assertThat(context).hasSingleBean(BeanDetailsRestController.class);
+            assertThat(context.getBean(BeanDetailsRestController.class)).isNotNull();
+        });
+    }
+}

--- a/spring-lens-exposure-http/pom.xml
+++ b/spring-lens-exposure-http/pom.xml
@@ -30,6 +30,16 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spring-lens-exposure-http/src/main/java/com/sdlcpro/springlens/exposure/bean/BeanDetailsRestController.java
+++ b/spring-lens-exposure-http/src/main/java/com/sdlcpro/springlens/exposure/bean/BeanDetailsRestController.java
@@ -1,0 +1,57 @@
+package com.sdlcpro.springlens.exposure.bean;
+
+import com.sdlcpro.springlens.exposure.ApiResponseHandler;
+import com.sdlcpro.springlens.query.PageRequest;
+import com.sdlcpro.springlens.query.Sort;
+import com.sdlcpro.springlens.repository.bean.BeanDefinitionInfoRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller that exposes the bean metadata collected by Spring Lens.
+ */
+@RestController
+@RequestMapping("/spring-lens/api/bean-definitions")
+public class BeanDetailsRestController {
+
+    private final BeanDefinitionInfoRepository beanDefinitionInfoRepository;
+
+    /**
+     * Creates a new controller backed by the given repository.
+     *
+     * @param beanDefinitionInfoRepository the repository holding the collected bean
+     *                                     metadata; must not be {@code null}
+     */
+    public BeanDetailsRestController(BeanDefinitionInfoRepository beanDefinitionInfoRepository) {
+        this.beanDefinitionInfoRepository = beanDefinitionInfoRepository;
+    }
+
+    /**
+     * Returns a page of collected bean metadata.
+     *
+     * @param page      zero-based page index (defaults to {@code 0})
+     * @param size      the number of records per page (defaults to {@code 20})
+     * @param sortBy    optional property name to sort by
+     * @param direction optional sort direction ({@code ASC} or {@code DESC}); defaults to
+     *                  ascending when a {@code sortBy} property is supplied
+     * @return a {@link ResponseEntity} wrapping the requested
+     *         {@link com.sdlcpro.springlens.query.PageResponse page} of bean definitions
+     */
+    @GetMapping
+    public ResponseEntity<?> getBeanDefinitions(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String sortBy,
+            @RequestParam(required = false) String direction) {
+        return ApiResponseHandler.handle(() -> {
+            Sort sort = (sortBy == null || sortBy.isBlank())
+                    ? Sort.unsorted()
+                    : Sort.by(sortBy, direction);
+            PageRequest pageRequest = new PageRequest(page, size, sort);
+            return beanDefinitionInfoRepository.findAll(pageRequest);
+        });
+    }
+}

--- a/spring-lens-exposure-http/src/test/java/com/sdlcpro/springlens/exposure/bean/BeanDetailsRestControllerTest.java
+++ b/spring-lens-exposure-http/src/test/java/com/sdlcpro/springlens/exposure/bean/BeanDetailsRestControllerTest.java
@@ -1,0 +1,89 @@
+package com.sdlcpro.springlens.exposure.bean;
+
+import com.sdlcpro.springlens.model.bean.BeanRole;
+import com.sdlcpro.springlens.model.bean.definition.BeanDefinitionInfo;
+import com.sdlcpro.springlens.query.PageRequest;
+import com.sdlcpro.springlens.query.PageResponse;
+import com.sdlcpro.springlens.repository.bean.BeanDefinitionInfoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BeanDetailsRestControllerTest {
+
+    private BeanDefinitionInfoRepository repository;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        this.repository = mock(BeanDefinitionInfoRepository.class);
+        BeanDetailsRestController controller = new BeanDetailsRestController(repository);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void shouldExposePaginatedBeanMetadata() throws Exception {
+        PageRequest pageRequest = new PageRequest(0, 20, com.sdlcpro.springlens.query.Sort.unsorted());
+        PageResponse<BeanDefinitionInfo> pageResponse = new PageResponse<>(
+                List.of(sampleBean("dataSource"), sampleBean("entityManager")),
+                pageRequest,
+                2
+        );
+        when(repository.findAll(any(PageRequest.class))).thenReturn(pageResponse);
+
+        mockMvc.perform(get("/spring-lens/api/bean-definitions")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.content[0].beanName").value("dataSource"))
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.pageNumber").value(0))
+                .andExpect(jsonPath("$.pageSize").value(20));
+    }
+
+    @Test
+    void shouldReturnEmptyContentWhenNoBeansCollected() throws Exception {
+        PageRequest pageRequest = new PageRequest(0, 20, com.sdlcpro.springlens.query.Sort.unsorted());
+        PageResponse<BeanDefinitionInfo> pageResponse = new PageResponse<>(List.of(), pageRequest, 0);
+        when(repository.findAll(any(PageRequest.class))).thenReturn(pageResponse);
+
+        mockMvc.perform(get("/spring-lens/api/bean-definitions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)))
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    private static BeanDefinitionInfo sampleBean(String beanName) {
+        return new BeanDefinitionInfo(
+                "application",
+                beanName,
+                List.of(),
+                "com.example." + beanName,
+                null,
+                null,
+                "singleton",
+                false,
+                false,
+                true,
+                BeanRole.ROLE_APPLICATION,
+                null,
+                null,
+                null,
+                null,
+                List.of(),
+                List.of()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Registers `BeanDetailsRestController` to expose collected bean metadata via REST,
active only in servlet web applications.

Closes #16

> **Note:** This endpoint returns empty/null results until #10 lands, since the
> default `InMemoryBeanDefinitionInfoRepository.findAll(PageRequest)` is still
> stubbed. This PR wires the controller to the repository; populating real data
> is owned by #10.

## Changes
- Add `BeanDetailsRestController` (`spring-lens-exposure-http`) — `@RestController`
  at `/spring-lens/api/bean-definitions` returning a paginated page of bean
  definitions from `BeanDefinitionInfoRepository` (`page`, `size`, `sortBy`,
  `direction` params).
- Add `BeanWebConfiguration` (`spring-lens-autoconfigure`) annotated with
  `@SpringLensInternalComponent` and `@ConditionalOnWebApplication(type = SERVLET)`,
  defining bean `springLensBeanDetailsRestController` wired to the repository.
- Add MockMvc endpoint tests and context-runner tests verifying conditional
  registration (web vs non-web) and repository wiring.
- Add test-scoped `jakarta.servlet-api` and `jackson-databind` to
  `spring-lens-exposure-http` for MockMvc/JSON in tests only.

## Acceptance Criteria
- [x] REST controller available in web applications
- [x] Exposes paginated bean metadata endpoint
- [x] Controller not registered in non-web environments
- [x] Controller correctly wired to repository

## Testing
- `spring-lens-exposure-http` and `spring-lens-autoconfigure` modules: all tests pass.