### PR TITLE
Fix/184 http request info

### DIFF
--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/HttpRequestInfo.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/HttpRequestInfo.java
@@ -1,0 +1,34 @@
+package com.sdlcpro.springlens.model.http;
+
+import com.sdlcpro.springlens.model.http.request.HttpRequestData;
+import com.sdlcpro.springlens.model.http.response.HttpResponseData;
+import com.sdlcpro.springlens.util.Preconditions;
+
+import java.time.Instant;
+
+/**
+ * Immutable top-level record aggregating the captured request and response
+ * snapshots of a single HTTP transaction, along with runtime execution
+ * metrics such as timing, asynchronous processing state, and any
+ * unhandled exception that occurred during processing.
+ */
+public record HttpRequestInfo(
+        HttpRequestData requestData,
+        HttpResponseData responseData,
+        Instant startTime,
+        long durationNanos,
+        boolean asyncRequest,
+        boolean asyncTimeout,
+        Throwable error) {
+
+    public HttpRequestInfo {
+        Preconditions.notNull(requestData, "HttpRequestData must not be null");
+        Preconditions.notNull(responseData, "HttpResponseData must not be null");
+        Preconditions.notNull(startTime, "The value of startTime must not be null");
+        Preconditions.isTrue(durationNanos >= 0, "The value of durationNanos must be non-negative");
+
+        Preconditions.isTrue(
+                asyncRequest || !asyncTimeout,
+                "The value of asyncTimeout cannot be true when asyncRequest is false");
+    }
+}

--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/response/HttpResponseData.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/response/HttpResponseData.java
@@ -44,10 +44,6 @@ public final class HttpResponseData {
                 : this.responseBody.getBytes(StandardCharsets.UTF_8).length < this.contentSize;
     }
 
-    public HttpResponseStatus getStatus() {
-        return this.status;
-    }
-
     public String getStatusName() {
         return this.status.name();
     }

--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/response/HttpResponseData.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/response/HttpResponseData.java
@@ -1,0 +1,85 @@
+package com.sdlcpro.springlens.model.http.response;
+
+import com.sdlcpro.springlens.model.http.HttpResponseStatus;
+import com.sdlcpro.springlens.model.http.request.Header;
+import com.sdlcpro.springlens.util.Preconditions;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Immutable snapshot of an outbound HTTP response captured at the
+ * interceptor boundary, used as the source data for trace recording.
+ * <p>
+ * Declared as a classic final POJO rather than a record so that the
+ * truncation flag can be pre-computed once in the constructor and
+ * exposed as a plain field, avoiding repeated byte-length computation
+ * on every {@link #isBodyTruncated()} call.
+ */
+public final class HttpResponseData {
+
+    private final HttpResponseStatus status;
+    private final String contentType;
+    private final int contentSize;
+    private final List<Header> responseHeaders;
+    private final String responseBody;
+    private final boolean bodyTruncated;
+
+    public HttpResponseData(HttpResponseStatus status, String contentType, int contentSize,
+            List<Header> responseHeaders, String responseBody) {
+        this.status = Preconditions.requireNonNull(status, "HttpResponseStatus must not be null");
+        this.contentType = contentType;
+        this.contentSize = contentSize;
+        this.responseBody = responseBody;
+
+        if (responseHeaders == null) {
+            this.responseHeaders = List.of();
+        } else {
+            Preconditions.noNullElements(responseHeaders, "The responseHeaders must not contain null elements");
+            this.responseHeaders = List.copyOf(responseHeaders);
+        }
+
+        this.bodyTruncated = this.responseBody == null
+                ? this.contentSize > 0
+                : this.responseBody.getBytes(StandardCharsets.UTF_8).length < this.contentSize;
+    }
+
+    public HttpResponseStatus getStatus() {
+        return this.status;
+    }
+
+    public String getStatusName() {
+        return this.status.name();
+    }
+
+    public int getStatusCode() {
+        return this.status.getCode();
+    }
+
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    public int getContentSize() {
+        return this.contentSize;
+    }
+
+    public List<Header> getResponseHeaders() {
+        return this.responseHeaders;
+    }
+
+    public String getResponseBody() {
+        return this.responseBody;
+    }
+
+    /**
+     * Indicates whether the captured response body was truncated relative
+     * to the declared content size, e.g. when the interceptor stopped
+     * reading before the full payload arrived.
+     *
+     * @return {@code true} if fewer bytes were captured than declared
+     */
+    public boolean isBodyTruncated() {
+        return this.bodyTruncated;
+    }
+}

--- a/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/HttpRequestInfoTest.java
+++ b/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/HttpRequestInfoTest.java
@@ -1,0 +1,115 @@
+package com.sdlcpro.springlens.model.http;
+
+import com.sdlcpro.springlens.model.http.request.HttpRequestData;
+import com.sdlcpro.springlens.model.http.response.HttpResponseData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpRequestInfoTest {
+
+    private HttpRequestData sampleRequestData() {
+        return new HttpRequestData(
+                HttpRequestMethod.GET,
+                "/api/orders",
+                Map.of(),
+                "HTTP/1.1",
+                "application/json",
+                0,
+                "127.0.0.1",
+                List.of(),
+                null);
+    }
+
+    private HttpResponseData sampleResponseData() {
+        return new HttpResponseData(
+                HttpResponseStatus.OK,
+                "application/json",
+                0,
+                List.of(),
+                null);
+    }
+
+    @Test
+    @DisplayName("should construct successfully with valid arguments")
+    void constructsSuccessfullyWithValidArguments() {
+        HttpRequestInfo info = new HttpRequestInfo(
+                sampleRequestData(), sampleResponseData(), Instant.now(), 1000L, false, false, null);
+
+        assertEquals(1000L, info.durationNanos());
+        assertFalse(info.asyncRequest());
+        assertFalse(info.asyncTimeout());
+        assertNull(info.error());
+    }
+
+    @Test
+    @DisplayName("should reject null requestData")
+    void rejectsNullRequestData() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new HttpRequestInfo(null, sampleResponseData(), Instant.now(), 0, false, false, null));
+    }
+
+    @Test
+    @DisplayName("should reject null responseData")
+    void rejectsNullResponseData() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new HttpRequestInfo(sampleRequestData(), null, Instant.now(), 0, false, false, null));
+    }
+
+    @Test
+    @DisplayName("should reject null startTime")
+    void rejectsNullStartTime() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new HttpRequestInfo(sampleRequestData(), sampleResponseData(), null, 0, false, false, null));
+    }
+
+    @Test
+    @DisplayName("should reject negative durationNanos")
+    void rejectsNegativeDuration() {
+        assertThrows(IllegalArgumentException.class, () -> new HttpRequestInfo(sampleRequestData(),
+                sampleResponseData(), Instant.now(), -1, false, false, null));
+    }
+
+    @Test
+    @DisplayName("should accept zero durationNanos")
+    void acceptsZeroDuration() {
+        assertDoesNotThrow(() -> new HttpRequestInfo(sampleRequestData(), sampleResponseData(), Instant.now(), 0, false,
+                false, null));
+    }
+
+    @Test
+    @DisplayName("should reject asyncTimeout true when asyncRequest is false")
+    void rejectsAsyncTimeoutWithoutAsyncRequest() {
+        assertThrows(IllegalArgumentException.class, () -> new HttpRequestInfo(sampleRequestData(),
+                sampleResponseData(), Instant.now(), 0, false, true, null));
+    }
+
+    @Test
+    @DisplayName("should accept asyncTimeout true when asyncRequest is true")
+    void acceptsAsyncTimeoutWithAsyncRequest() {
+        assertDoesNotThrow(() -> new HttpRequestInfo(sampleRequestData(), sampleResponseData(), Instant.now(), 0, true,
+                true, null));
+    }
+
+    @Test
+    @DisplayName("should accept asyncRequest true with asyncTimeout false")
+    void acceptsAsyncRequestWithoutTimeout() {
+        assertDoesNotThrow(() -> new HttpRequestInfo(sampleRequestData(), sampleResponseData(), Instant.now(), 0, true,
+                false, null));
+    }
+
+    @Test
+    @DisplayName("should carry the captured error when processing failed")
+    void carriesProcessingError() {
+        RuntimeException error = new RuntimeException("boom");
+        HttpRequestInfo info = new HttpRequestInfo(
+                sampleRequestData(), sampleResponseData(), Instant.now(), 0, false, false, error);
+
+        assertSame(error, info.error());
+    }
+}

--- a/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/response/HttpResponseDataTest.java
+++ b/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/response/HttpResponseDataTest.java
@@ -1,0 +1,108 @@
+package com.sdlcpro.springlens.model.http.response;
+
+import com.sdlcpro.springlens.model.http.HttpResponseStatus;
+import com.sdlcpro.springlens.model.http.request.Header;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpResponseDataTest {
+
+    @Test
+    @DisplayName("should reject null status")
+    void rejectsNullStatus() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new HttpResponseData(null, "application/json", 0, List.of(), null));
+    }
+
+    @Test
+    @DisplayName("should expose status name and code from HttpResponseStatus")
+    void exposesStatusNameAndCode() {
+        HttpResponseData data = new HttpResponseData(
+                HttpResponseStatus.NOT_FOUND, "application/json", 0, List.of(), null);
+
+        assertEquals(HttpResponseStatus.NOT_FOUND, data.getStatus());
+        assertEquals("NOT_FOUND", data.getStatusName());
+        assertEquals(404, data.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("should default null response headers to an empty list")
+    void defaultsNullHeadersToEmptyList() {
+        HttpResponseData data = new HttpResponseData(
+                HttpResponseStatus.OK, "text/plain", 0, null, null);
+
+        assertTrue(data.getResponseHeaders().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should reject response headers list containing null elements")
+    void rejectsNullElementInResponseHeaders() {
+        List<Header> headers = new ArrayList<>();
+        headers.add(new Header("Content-Type", List.of("application/json")));
+        headers.add(null);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new HttpResponseData(HttpResponseStatus.OK, "application/json", 0, headers, null));
+    }
+
+    @Test
+    @DisplayName("response headers list should be immutable")
+    void responseHeadersListIsImmutable() {
+        HttpResponseData data = new HttpResponseData(
+                HttpResponseStatus.OK, "application/json", 0,
+                List.of(new Header("Content-Type", List.of("application/json"))), null);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> data.getResponseHeaders().add(new Header("X-Extra", List.of("value"))));
+    }
+
+    @Test
+    @DisplayName("should not be affected by mutating the original headers list after construction")
+    void isNotAffectedByMutatingOriginalListAfterConstruction() {
+        List<Header> original = new ArrayList<>();
+        original.add(new Header("Content-Type", List.of("application/json")));
+
+        HttpResponseData data = new HttpResponseData(
+                HttpResponseStatus.OK, "application/json", 0, original, null);
+
+        original.add(new Header("X-Extra", List.of("leaked")));
+
+        assertEquals(1, data.getResponseHeaders().size());
+    }
+
+    @Test
+    @DisplayName("should flag body as truncated when captured bytes are fewer than declared content size")
+    void flagsTruncatedBody() {
+        HttpResponseData data = new HttpResponseData(
+                HttpResponseStatus.OK, "text/plain", 100, List.of(), "partial");
+
+        assertTrue(data.isBodyTruncated());
+    }
+
+    @Test
+    @DisplayName("should not flag body as truncated when full content was captured")
+    void doesNotFlagCompleteBody() {
+        String body = "{\"ok\":true}";
+        int size = body.getBytes(StandardCharsets.UTF_8).length;
+
+        HttpResponseData data = new HttpResponseData(
+                HttpResponseStatus.OK, "application/json", size, List.of(), body);
+
+        assertFalse(data.isBodyTruncated());
+    }
+
+    @Test
+    @DisplayName("should flag body as truncated when body is null but content size is positive")
+    void flagsTruncatedWhenBodyNullAndContentSizePositive() {
+        HttpResponseData data = new HttpResponseData(
+                HttpResponseStatus.OK, "application/json", 50, List.of(), null);
+
+        assertTrue(data.isBodyTruncated());
+    }
+}

--- a/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/response/HttpResponseDataTest.java
+++ b/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/response/HttpResponseDataTest.java
@@ -26,7 +26,6 @@ class HttpResponseDataTest {
         HttpResponseData data = new HttpResponseData(
                 HttpResponseStatus.NOT_FOUND, "application/json", 0, List.of(), null);
 
-        assertEquals(HttpResponseStatus.NOT_FOUND, data.getStatus());
         assertEquals("NOT_FOUND", data.getStatusName());
         assertEquals(404, data.getStatusCode());
     }


### PR DESCRIPTION
Implements HttpRequestInfo as specified in the ticket, no changes to the proposed
logic, all the validation rules (non-null checks, non-negative duration, the
async/timeout state invariant) worked as described. Just implemented it and
added tests covering the normal construction path plus each validation failure
case.

Depends on #183 (HttpResponseData), which is included/merged as part of this
work.

#184