### PR TITLE
feat(insight): introduce HandlerTypeMatcher for endpoint filtering (#212)

### DIFF
--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeMatcher.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeMatcher.java
@@ -1,0 +1,76 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.matcher.Matcher;
+import com.sdlcpro.springlens.model.http.endpoint.HandlerType;
+import org.springframework.util.CollectionUtils;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * A concrete {@link Matcher} that filters and evaluates candidate HTTP endpoints
+ * based on their designated {@link HandlerType}.
+ *
+ * <p>This matcher integrates into composite evaluation pipelines by consuming
+ * objects that implement {@link HandlerTypeProvider}, allowing framework scanning
+ * components to filter routes based on handler classifications — such as
+ * controller methods, functional WebFlux handlers, or custom/unknown handlers —
+ * in a type-safe manner.</p>
+ *
+ * <p>The configured target set is defensively copied into an immutable
+ * {@link EnumSet} at construction time. A {@code null} or empty input set
+ * yields an empty matching set, which causes every evaluation to fail.</p>
+ *
+ * @param <T> the type of context being matched; must expose its
+ *            {@link HandlerType} via {@link HandlerTypeProvider}
+ * @since 1.0.0
+ * @see HandlerTypeProvider
+ * @see HandlerType
+ * @see Matcher
+ */
+public class HandlerTypeMatcher<T extends HandlerTypeProvider> implements Matcher<T> {
+
+    private final Set<HandlerType> handlerTypes;
+
+    /**
+     * Creates a matcher that accepts contexts whose {@link HandlerType} is
+     * contained in the given set.
+     *
+     * <p>When {@code handlerTypes} is {@code null} or empty, an empty
+     * {@link EnumSet} is used and {@link #matches} will always return
+     * {@code false}. Otherwise the set is copied via
+     * {@link EnumSet#copyOf(java.util.Collection)} to guarantee immutability
+     * of the matcher's internal state.</p>
+     *
+     * @param handlerTypes the handler types to match against; may be
+     *                     {@code null} or empty
+     */
+    public HandlerTypeMatcher(Set<HandlerType> handlerTypes) {
+        this.handlerTypes = CollectionUtils.isEmpty(handlerTypes)
+                ? EnumSet.noneOf(HandlerType.class)
+                : EnumSet.copyOf(handlerTypes);
+    }
+
+    /**
+     * Evaluates whether the given context's handler type is among the
+     * configured target types.
+     *
+     * <p>Returns {@code false} when {@code context} is {@code null}, when
+     * {@link HandlerTypeProvider#getHandlerType()} returns {@code null}, or
+     * when the configured handler-type set is empty. Otherwise returns
+     * whether the candidate's handler type is contained in the matching set.</p>
+     *
+     * @param context the evaluation context providing a {@link HandlerType};
+     *                may be {@code null}
+     * @return {@code true} if the context's handler type is accepted by this
+     *         matcher; {@code false} otherwise
+     */
+    @Override
+    public boolean matches(T context) {
+        if (context == null || context.getHandlerType() == null || CollectionUtils.isEmpty(this.handlerTypes)) {
+            return false;
+        }
+
+        return this.handlerTypes.contains(context.getHandlerType());
+    }
+}

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeProvider.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeProvider.java
@@ -1,0 +1,34 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.model.http.endpoint.HandlerType;
+
+/**
+ * A functional provider interface that exposes the {@link HandlerType} of a
+ * target HTTP endpoint insight tracking object.
+ *
+ * <p>By abstracting the handler classification behind this provider contract,
+ * route-filtering and metadata processing logic is cleanly decoupled from
+ * concrete endpoint models. Consumers can uniformly query whether an endpoint
+ * is backed by a {@linkplain HandlerType#CONTROLLER controller},
+ * {@linkplain HandlerType#FUNCTIONAL functional} handler, or an
+ * {@linkplain HandlerType#UNKNOWN unknown} execution model without depending
+ * on the specific model hierarchy that produced the classification.</p>
+ *
+ * <p>Because this interface declares exactly one abstract method, it is
+ * marked as a {@link FunctionalInterface} and can be expressed as a
+ * lambda expression or method reference.</p>
+ *
+ * @since 1.0.0
+ * @see HandlerType
+ */
+@FunctionalInterface
+public interface HandlerTypeProvider {
+
+    /**
+     * Returns the {@link HandlerType} associated with the target endpoint.
+     *
+     * @return the handler type classification, or {@code null} when the type
+     *         cannot be determined by the provider implementation
+     */
+    HandlerType getHandlerType();
+}

--- a/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeMatcherTest.java
+++ b/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeMatcherTest.java
@@ -1,0 +1,126 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.model.http.endpoint.HandlerType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HandlerTypeMatcherTest {
+
+    private record TestProvider(HandlerType handlerType) implements HandlerTypeProvider {
+
+        @Override
+        public HandlerType getHandlerType() {
+            return handlerType;
+        }
+    }
+
+    @Test
+    @DisplayName("should return false when matcher is created with null set")
+    void shouldReturnFalseForNullSet() {
+        HandlerTypeMatcher<TestProvider> matcher = new HandlerTypeMatcher<>(null);
+        assertFalse(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+    }
+
+    @Test
+    @DisplayName("should return false when matcher is created with empty set")
+    void shouldReturnFalseForEmptySet() {
+        HandlerTypeMatcher<TestProvider> matcher = new HandlerTypeMatcher<>(Set.of());
+        assertFalse(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+    }
+
+    @Test
+    @DisplayName("should return false for null context")
+    void shouldReturnFalseForNullContext() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER));
+        assertFalse(matcher.matches(null));
+    }
+
+    @Test
+    @DisplayName("should return false when context handler type is null")
+    void shouldReturnFalseForNullHandlerType() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER));
+        assertFalse(matcher.matches(new TestProvider(null)));
+    }
+
+    @Test
+    @DisplayName("should return false when handler type does not match")
+    void shouldReturnFalseForNonMatchingHandlerType() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER));
+        assertFalse(matcher.matches(new TestProvider(HandlerType.FUNCTIONAL)));
+        assertFalse(matcher.matches(new TestProvider(HandlerType.UNKNOWN)));
+    }
+
+    @Test
+    @DisplayName("should return true when handler type matches")
+    void shouldReturnTrueForMatchingHandlerType() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER, HandlerType.FUNCTIONAL));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.FUNCTIONAL)));
+    }
+
+    @Test
+    @DisplayName("should match UNKNOWN when included in target set")
+    void shouldMatchUnknownWhenConfigured() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.UNKNOWN));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.UNKNOWN)));
+        assertFalse(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+    }
+
+    @Test
+    @DisplayName("should defensively copy supplied set")
+    void shouldDefensivelyCopyInputSet() {
+        Set<HandlerType> handlerTypes = new HashSet<>();
+        handlerTypes.add(HandlerType.CONTROLLER);
+
+        HandlerTypeMatcher<TestProvider> matcher = new HandlerTypeMatcher<>(handlerTypes);
+
+        handlerTypes.add(HandlerType.FUNCTIONAL);
+
+        assertFalse(matcher.matches(new TestProvider(HandlerType.FUNCTIONAL)));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+    }
+
+    @Test
+    @DisplayName("should reject null elements in supplied set")
+    void shouldRejectNullElements() {
+        Set<HandlerType> handlerTypes = new HashSet<>();
+        handlerTypes.add(null);
+
+        assertThrows(
+                NullPointerException.class,
+                () -> new HandlerTypeMatcher<>(handlerTypes)
+        );
+    }
+
+    @Test
+    @DisplayName("should match against second element when first does not match")
+    void shouldMatchAgainstSecondElement() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER, HandlerType.FUNCTIONAL));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.FUNCTIONAL)));
+    }
+
+    @Test
+    @DisplayName("should accept all HandlerType values when configured with allOf")
+    void shouldMatchAllHandlerTypesWhenConfiguredWithAllOf() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.allOf(HandlerType.class));
+
+        for (HandlerType type : HandlerType.values()) {
+            assertTrue(matcher.matches(new TestProvider(type)));
+        }
+    }
+}


### PR DESCRIPTION
- Add HandlerTypeMatcher implementing Matcher<T extends HandlerTypeProvider>
- Enforce immutability using EnumSet defensive copying
- Add unit tests covering matching logic and null/empty set edge cases