### PR TITLE
feat: add EndpointInfoCollector

### DIFF
--- a/spring-lens-insight/pom.xml
+++ b/spring-lens-insight/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <optional>true</optional>

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/EndpointInfoCollector.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/EndpointInfoCollector.java
@@ -1,0 +1,36 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.model.http.endpoint.EndpointInfo;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.List;
+
+/**
+ * Collects endpoint metadata from a Spring {@link HandlerMapping}.
+ *
+ * <p>Implementations support specific {@link HandlerMapping} types and extract
+ * a snapshot of their endpoint metadata.</p>
+ *
+ * @since 1.0.0
+ */
+public interface EndpointInfoCollector {
+
+    /**
+     * Determines whether this collector can process the given handler mapping.
+     *
+     * @param mapping the Spring handler mapping to evaluate
+     * @return {@code true} if this collector supports the mapping; {@code false}
+     * otherwise
+     */
+    default boolean supports(HandlerMapping mapping) {
+        return false;
+    }
+
+    /**
+     * Collects endpoint metadata from the given handler mapping.
+     *
+     * @param mapping the Spring handler mapping to inspect
+     * @return the collected endpoint metadata
+     */
+    List<EndpointInfo> collect(HandlerMapping mapping);
+}


### PR DESCRIPTION
## Summary

- add the `EndpointInfoCollector` contract for collecting endpoint metadata from Spring `HandlerMapping` instances
- add the required Spring MVC dependency
- document the interface and its methods

Closes #207

## Validation

- `mvn clean test`