### PR TITLE
feat: add HttpUriProvider

### DIFF
--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/HttpUriProvider.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/HttpUriProvider.java
@@ -1,0 +1,22 @@
+package com.sdlcpro.springlens.insight.http;
+
+/**
+ * A functional interface for retrieving the HTTP URI associated with a target
+ * endpoint or request context.
+ *
+ * <p>Implementations provide URI path patterns that can be used by endpoint
+ * analysis and matching components during framework scanning.</p>
+ *
+ * @since 1.0.0
+ */
+@FunctionalInterface
+public interface HttpUriProvider {
+
+    /**
+     * Returns the HTTP URI path or pattern associated with the target.
+     *
+     * @return the HTTP URI path or pattern
+     */
+    String getHttpUri();
+
+}


### PR DESCRIPTION
## Summary

- add the `HttpUriProvider` functional interface for retrieving HTTP URI paths
- document the interface and its `getHttpUri()` contract

Closes #213

## Validation

- `mvn -pl spring-lens-insight -am test`