### PR TITLE
feat(insight): add internal endpoint matcher

### DIFF
--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/ToolInternalEndpointMatcher.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/ToolInternalEndpointMatcher.java
@@ -1,0 +1,28 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.annotation.SpringLensEndpoint;
+import com.sdlcpro.springlens.insight.support.matcher.AnnotatedClassMatcher;
+import com.sdlcpro.springlens.insight.support.provider.ClassProvider;
+
+import java.util.Set;
+
+/**
+ * Matches internal Spring Lens HTTP endpoint components.
+ *
+ * <p>The matcher is preconfigured for {@link SpringLensEndpoint}, allowing
+ * endpoint collection to exclude framework-owned routes without requiring
+ * callers to supply annotation metadata.</p>
+ *
+ * @param <T> the type of context being matched; it must provide a class
+ * @since 1.0.0
+ */
+public class ToolInternalEndpointMatcher<T extends ClassProvider> extends AnnotatedClassMatcher<T> {
+
+    /**
+     * Creates a matcher that recognizes classes annotated with
+     * {@link SpringLensEndpoint}.
+     */
+    public ToolInternalEndpointMatcher() {
+        super(Set.of(SpringLensEndpoint.class));
+    }
+}

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/support/matcher/AnnotatedClassMatcher.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/support/matcher/AnnotatedClassMatcher.java
@@ -1,0 +1,47 @@
+package com.sdlcpro.springlens.insight.support.matcher;
+
+import com.sdlcpro.springlens.insight.support.provider.ClassProvider;
+import com.sdlcpro.springlens.matcher.Matcher;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+/**
+ * Matches contexts whose supplied class declares at least one configured annotation.
+ *
+ * @param <T> the type of context being matched; it must provide a class
+ * @since 1.0.0
+ */
+public class AnnotatedClassMatcher<T extends ClassProvider> implements Matcher<T> {
+
+    private final Set<Class<? extends Annotation>> annotations;
+
+    /**
+     * Creates a matcher for the supplied annotation types.
+     *
+     * @param annotations annotation types that a supplied class may declare
+     */
+    public AnnotatedClassMatcher(Set<Class<? extends Annotation>> annotations) {
+        this.annotations = Set.copyOf(annotations);
+    }
+
+    /**
+     * Determines whether the context supplies a class declaring any configured annotation.
+     *
+     * @param context the context to inspect; may be {@code null}
+     * @return {@code true} if the supplied class declares a configured annotation
+     */
+    @Override
+    public boolean matches(T context) {
+        if (context == null) {
+            return false;
+        }
+
+        Class<?> targetClass = context.getClazz();
+        if (targetClass == null) {
+            return false;
+        }
+
+        return annotations.stream().anyMatch(targetClass::isAnnotationPresent);
+    }
+}

--- a/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/endpoint/ToolInternalEndpointMatcherTest.java
+++ b/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/endpoint/ToolInternalEndpointMatcherTest.java
@@ -1,0 +1,30 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.annotation.SpringLensEndpoint;
+import com.sdlcpro.springlens.insight.support.provider.ClassProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolInternalEndpointMatcherTest {
+
+    private final ToolInternalEndpointMatcher<ClassProvider> matcher = new ToolInternalEndpointMatcher<>();
+
+    @Test
+    void shouldMatchClassAnnotatedAsSpringLensEndpoint() {
+        assertTrue(matcher.matches(() -> InternalEndpoint.class));
+    }
+
+    @Test
+    void shouldNotMatchClassWithoutSpringLensEndpointAnnotation() {
+        assertFalse(matcher.matches(() -> ApplicationEndpoint.class));
+    }
+
+    @SpringLensEndpoint
+    private static class InternalEndpoint {
+    }
+
+    private static class ApplicationEndpoint {
+    }
+}


### PR DESCRIPTION
## Summary

Implements #214 by adding `ToolInternalEndpointMatcher` for identifying Spring Lens internal endpoint classes annotated with `@SpringLensEndpoint`.

Because `AnnotatedClassMatcher` was not present in the current codebase, this PR also adds its minimal reusable implementation based on `ClassProvider#getClazz()`.

## Changes

- Add `AnnotatedClassMatcher<T extends ClassProvider>`
- Add `ToolInternalEndpointMatcher<T extends ClassProvider>`
- Add unit tests for annotated and unannotated endpoint classes

## Verification

```text
mvn '-Dmaven-compiler-plugin.version=3.8.1' -pl spring-lens-insight -am test