### PR TITLE
Add default BeanDefinitionInfoRepository auto-configuration

### DIFF
--- a/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/bean/BeanStorageConfiguration.java
+++ b/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/bean/BeanStorageConfiguration.java
@@ -1,0 +1,28 @@
+package com.sdlcpro.springlens.autoconfigure.bean;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.repository.bean.BeanDefinitionInfoRepository;
+import com.sdlcpro.springlens.storage.bean.definition.InMemoryBeanDefinitionInfoRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Configures the default storage for Spring Lens bean metadata.
+ *
+ * <p>An in-memory repository is registered when the application does not
+ * provide a custom {@link BeanDefinitionInfoRepository} implementation.</p>
+ */
+@SpringLensInternalComponent
+public class BeanStorageConfiguration {
+
+    /**
+     * Registers the default in-memory repository for bean definition metadata.
+     *
+     * @return the default bean definition information repository
+     */
+    @Bean("springLensInMemoryBeanDefinitionInfoRepository")
+    @ConditionalOnMissingBean(BeanDefinitionInfoRepository.class)
+    public BeanDefinitionInfoRepository beanDefinitionInfoRepository() {
+        return new InMemoryBeanDefinitionInfoRepository();
+    }
+}

--- a/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/bean/BeanStorageConfigurationTest.java
+++ b/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/bean/BeanStorageConfigurationTest.java
@@ -1,0 +1,50 @@
+package com.sdlcpro.springlens.autoconfigure.bean;
+
+import com.sdlcpro.springlens.repository.bean.BeanDefinitionInfoRepository;
+import com.sdlcpro.springlens.storage.bean.definition.InMemoryBeanDefinitionInfoRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+
+class BeanStorageConfigurationTest {
+
+    private static final String REPOSITORY_BEAN_NAME =
+            "springLensInMemoryBeanDefinitionInfoRepository";
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withUserConfiguration(BeanStorageConfiguration.class);
+
+    @Test
+    void registersDefaultRepositoryWhenNoCustomRepositoryExists() {
+        contextRunner.run(context -> {
+            assertThat(context).hasBean(REPOSITORY_BEAN_NAME);
+            assertThat(context).hasSingleBean(BeanDefinitionInfoRepository.class);
+            assertThat(context.getBean(BeanDefinitionInfoRepository.class))
+                    .isInstanceOf(InMemoryBeanDefinitionInfoRepository.class);
+        });
+    }
+
+    @Test
+    void backsOffWhenCustomRepositoryExists() {
+        BeanDefinitionInfoRepository customRepository =
+                mock(BeanDefinitionInfoRepository.class);
+
+        contextRunner
+                .withBean(
+                        "customBeanDefinitionInfoRepository",
+                        BeanDefinitionInfoRepository.class,
+                        () -> customRepository
+                )
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(REPOSITORY_BEAN_NAME);
+                    assertThat(context).hasSingleBean(BeanDefinitionInfoRepository.class);
+                    assertThat(context.getBean(BeanDefinitionInfoRepository.class))
+                            .isSameAs(customRepository);
+                });
+    }    
+}
+

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/ToolInternalEndpointMatcher.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/ToolInternalEndpointMatcher.java
@@ -1,0 +1,28 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.annotation.SpringLensEndpoint;
+import com.sdlcpro.springlens.insight.support.matcher.AnnotatedClassMatcher;
+import com.sdlcpro.springlens.insight.support.provider.ClassProvider;
+
+import java.util.Set;
+
+/**
+ * Matches internal Spring Lens HTTP endpoint components.
+ *
+ * <p>The matcher is preconfigured for {@link SpringLensEndpoint}, allowing
+ * endpoint collection to exclude framework-owned routes without requiring
+ * callers to supply annotation metadata.</p>
+ *
+ * @param <T> the type of context being matched; it must provide a class
+ * @since 1.0.0
+ */
+public class ToolInternalEndpointMatcher<T extends ClassProvider> extends AnnotatedClassMatcher<T> {
+
+    /**
+     * Creates a matcher that recognizes classes annotated with
+     * {@link SpringLensEndpoint}.
+     */
+    public ToolInternalEndpointMatcher() {
+        super(Set.of(SpringLensEndpoint.class));
+    }
+}

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/support/matcher/AnnotatedClassMatcher.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/support/matcher/AnnotatedClassMatcher.java
@@ -1,0 +1,47 @@
+package com.sdlcpro.springlens.insight.support.matcher;
+
+import com.sdlcpro.springlens.insight.support.provider.ClassProvider;
+import com.sdlcpro.springlens.matcher.Matcher;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+/**
+ * Matches contexts whose supplied class declares at least one configured annotation.
+ *
+ * @param <T> the type of context being matched; it must provide a class
+ * @since 1.0.0
+ */
+public class AnnotatedClassMatcher<T extends ClassProvider> implements Matcher<T> {
+
+    private final Set<Class<? extends Annotation>> annotations;
+
+    /**
+     * Creates a matcher for the supplied annotation types.
+     *
+     * @param annotations annotation types that a supplied class may declare
+     */
+    public AnnotatedClassMatcher(Set<Class<? extends Annotation>> annotations) {
+        this.annotations = Set.copyOf(annotations);
+    }
+
+    /**
+     * Determines whether the context supplies a class declaring any configured annotation.
+     *
+     * @param context the context to inspect; may be {@code null}
+     * @return {@code true} if the supplied class declares a configured annotation
+     */
+    @Override
+    public boolean matches(T context) {
+        if (context == null) {
+            return false;
+        }
+
+        Class<?> targetClass = context.getClazz();
+        if (targetClass == null) {
+            return false;
+        }
+
+        return annotations.stream().anyMatch(targetClass::isAnnotationPresent);
+    }
+}

--- a/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/endpoint/ToolInternalEndpointMatcherTest.java
+++ b/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/endpoint/ToolInternalEndpointMatcherTest.java
@@ -1,0 +1,30 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.annotation.SpringLensEndpoint;
+import com.sdlcpro.springlens.insight.support.provider.ClassProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolInternalEndpointMatcherTest {
+
+    private final ToolInternalEndpointMatcher<ClassProvider> matcher = new ToolInternalEndpointMatcher<>();
+
+    @Test
+    void shouldMatchClassAnnotatedAsSpringLensEndpoint() {
+        assertTrue(matcher.matches(() -> InternalEndpoint.class));
+    }
+
+    @Test
+    void shouldNotMatchClassWithoutSpringLensEndpointAnnotation() {
+        assertFalse(matcher.matches(() -> ApplicationEndpoint.class));
+    }
+
+    @SpringLensEndpoint
+    private static class InternalEndpoint {
+    }
+
+    private static class ApplicationEndpoint {
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds default auto-configuration for `BeanDefinitionInfoRepository`.

### Changes

- Add `BeanStorageConfiguration`
- Register `InMemoryBeanDefinitionInfoRepository` when no custom repository is provided
- Add tests covering:
  - default repository registration
  - back-off behavior when a custom repository exists

### Verification

- Added unit tests for both registration and back-off scenarios.
- Verified by running:

```bash
mvn -pl spring-lens-autoconfigure -am test
```

All tests pass successfully.