### PR TITLE
feat(storage): implement in-memory BeanDefinitionInfoRepository

### DIFF
--- a/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/bean/definition/InMemoryBeanDefinitionInfoRepository.java
+++ b/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/bean/definition/InMemoryBeanDefinitionInfoRepository.java
@@ -6,67 +6,64 @@ import com.sdlcpro.springlens.model.bean.definition.BeanDefinitionInfo;
 import com.sdlcpro.springlens.query.Filter;
 import com.sdlcpro.springlens.query.PageRequest;
 import com.sdlcpro.springlens.query.PageResponse;
+import com.sdlcpro.springlens.query.QueryExecutor;
 import com.sdlcpro.springlens.repository.bean.BeanDefinitionInfoRepository;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * In-memory implementation of {@link BeanDefinitionInfoRepository}.
  *
- * <p>This class provides the architectural footprint for an in-memory store
- * of {@link BeanDefinitionInfo} instances. All methods are currently stubbed
- * with default empty structures or {@code null} return values, and are
- * explicitly marked with {@code // TODO} comments for future sprint
- * iterations.</p>
+ * <p>Stores {@link BeanDefinitionInfo} instances in a {@link ConcurrentHashMap}
+ * keyed by {@link BeanInfoCompositeKey}. Paged and filtered queries delegate to
+ * {@link QueryExecutor}.</p>
  *
  * @since 1.0.0
  */
 @SpringLensInternalComponent
 public class InMemoryBeanDefinitionInfoRepository implements BeanDefinitionInfoRepository {
 
-    // ==================== Repository<T, ID> methods ====================
+    private final ConcurrentHashMap<BeanInfoCompositeKey, BeanDefinitionInfo> store =
+            new ConcurrentHashMap<>();
+    private final QueryExecutor<BeanDefinitionInfo> queryExecutor =
+            new QueryExecutor<>(BeanDefinitionInfo.class);
 
     @Override
     public void save(BeanDefinitionInfo entity) {
-        // TODO: provide appropriate implementation
+        BeanInfoCompositeKey key = new BeanInfoCompositeKey(entity.contextId(), entity.beanName());
+        store.put(key, entity);
     }
 
     @Override
     public List<BeanDefinitionInfo> findAll() {
-        // TODO: provide appropriate implementation
-        return Collections.emptyList();
+        return new ArrayList<>(store.values());
     }
 
     @Override
     public Optional<BeanDefinitionInfo> findById(BeanInfoCompositeKey id) {
-        // TODO: provide appropriate implementation
-        return Optional.empty();
+        return Optional.ofNullable(store.get(id));
     }
 
     @Override
     public void deleteById(BeanInfoCompositeKey id) {
-        // TODO: provide appropriate implementation
+        store.remove(id);
     }
 
     @Override
     public long count() {
-        // TODO: provide appropriate implementation
-        return 0;
+        return store.size();
     }
-
-    // ==================== PageableRepository<T, ID> methods ====================
 
     @Override
     public PageResponse<BeanDefinitionInfo> findAll(PageRequest pageRequest) {
-        // TODO: provide appropriate implementation
-        return null;
+        return queryExecutor.execute(store.values(), Filter.UNFILTERED, pageRequest);
     }
 
     @Override
     public PageResponse<BeanDefinitionInfo> findAll(Filter filter, PageRequest pageRequest) {
-        // TODO: provide appropriate implementation
-        return null;
+        return queryExecutor.execute(store.values(), filter, pageRequest);
     }
 }

--- a/spring-lens-storage/src/test/java/com/sdlcpro/springlens/storage/bean/definition/InMemoryBeanDefinitionInfoRepositoryTest.java
+++ b/spring-lens-storage/src/test/java/com/sdlcpro/springlens/storage/bean/definition/InMemoryBeanDefinitionInfoRepositoryTest.java
@@ -1,0 +1,107 @@
+package com.sdlcpro.springlens.storage.bean.definition;
+
+import com.sdlcpro.springlens.model.bean.BeanInfoCompositeKey;
+import com.sdlcpro.springlens.model.bean.BeanRole;
+import com.sdlcpro.springlens.model.bean.definition.BeanDefinitionInfo;
+import com.sdlcpro.springlens.query.Filters;
+import com.sdlcpro.springlens.query.PageRequest;
+import com.sdlcpro.springlens.query.PageResponse;
+import com.sdlcpro.springlens.query.Sort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryBeanDefinitionInfoRepositoryTest {
+
+    private InMemoryBeanDefinitionInfoRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryBeanDefinitionInfoRepository();
+    }
+
+    private static BeanDefinitionInfo bean(String contextId, String beanName) {
+        return new BeanDefinitionInfo(
+                contextId,
+                beanName,
+                List.of(),
+                "com.example." + beanName,
+                null,
+                null,
+                "singleton",
+                false,
+                false,
+                true,
+                BeanRole.ROLE_APPLICATION,
+                null,
+                null,
+                null,
+                null,
+                List.of(),
+                List.of()
+        );
+    }
+
+    @Test
+    void saveThenFindByIdAndCount() {
+        BeanDefinitionInfo info = bean("ctx", "alpha");
+        repository.save(info);
+
+        assertThat(repository.count()).isEqualTo(1);
+        assertThat(repository.findById(new BeanInfoCompositeKey("ctx", "alpha")))
+                .contains(info);
+        assertThat(repository.findAll()).containsExactly(info);
+    }
+
+    @Test
+    void saveOverwritesSameCompositeKey() {
+        repository.save(bean("ctx", "alpha"));
+        BeanDefinitionInfo updated = new BeanDefinitionInfo(
+                "ctx", "alpha", List.of("alias"), "com.example.Updated", null, null,
+                "singleton", true, true, true, BeanRole.ROLE_APPLICATION,
+                null, null, null, null, List.of(), List.of());
+        repository.save(updated);
+
+        assertThat(repository.count()).isEqualTo(1);
+        assertThat(repository.findById(new BeanInfoCompositeKey("ctx", "alpha")))
+                .contains(updated);
+    }
+
+    @Test
+    void deleteByIdRemovesEntry() {
+        repository.save(bean("ctx", "alpha"));
+        repository.deleteById(new BeanInfoCompositeKey("ctx", "alpha"));
+        assertThat(repository.count()).isZero();
+        assertThat(repository.findById(new BeanInfoCompositeKey("ctx", "alpha"))).isEmpty();
+    }
+
+    @Test
+    void findAllWithPageRequestPaginates() {
+        repository.save(bean("ctx", "a"));
+        repository.save(bean("ctx", "b"));
+        repository.save(bean("ctx", "c"));
+
+        PageRequest page0 = new PageRequest(0, 2, Sort.unsorted());
+        PageResponse<BeanDefinitionInfo> response = repository.findAll(page0);
+
+        assertThat(response.getTotalElements()).isEqualTo(3);
+        assertThat(response.getContent()).hasSize(2);
+    }
+
+    @Test
+    void findAllWithFilterAndPageRequest() {
+        repository.save(bean("ctx", "keepMe"));
+        repository.save(bean("ctx", "skipMe"));
+
+        PageRequest page = new PageRequest(0, 10, Sort.unsorted());
+        PageResponse<BeanDefinitionInfo> response =
+                repository.findAll(Filters.eq("beanName", "keepMe"), page);
+
+        assertThat(response.getTotalElements()).isEqualTo(1);
+        assertThat(response.getContent()).extracting(BeanDefinitionInfo::beanName)
+                .containsExactly("keepMe");
+    }
+}


### PR DESCRIPTION
## Summary
- Implement real `InMemoryBeanDefinitionInfoRepository` with `ConcurrentHashMap` storage
- Page/filter via existing core `QueryExecutor` (replaces stub no-op `save`/`findAll`)
- Unit tests for save/find/count, overwrite, delete, pagination, and filtered page

Closes #10 (stub completion for Bean Definition Discovery chain).

## Test plan
- [ ] `mvn test -Dtest=InMemoryBeanDefinitionInfoRepositoryTest -pl :spring-lens-storage`
- [ ] Confirm `save` then `findById` / `count` round-trip
- [ ] Confirm paged `findAll(PageRequest)` and `findAll(Filter, PageRequest)` behave
