### PR TITLE
Feat/224 226 bean info utils endpoint listener

### DIFF
--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/listener/http/endpoint/EndpointInfoListener.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/listener/http/endpoint/EndpointInfoListener.java
@@ -1,0 +1,17 @@
+package com.sdlcpro.springlens.listener.http.endpoint;
+
+import com.sdlcpro.springlens.model.http.endpoint.EndpointInfo;
+
+/**
+ * Functional callback contract for receiving collected {@link EndpointInfo}
+ * domain models during framework scanning and route discovery phases.
+ */
+@FunctionalInterface
+public interface EndpointInfoListener {
+    /**
+     * Callback method triggered when EndpointInfo is collected.
+     *
+     * @param endpointInfo the collected HTTP endpoint metadata
+     */
+    void onEndpointInfoCollect(EndpointInfo endpointInfo);
+}

--- a/spring-lens-insight/pom.xml
+++ b/spring-lens-insight/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <optional>true</optional>

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/BeanInfoUtils.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/BeanInfoUtils.java
@@ -1,0 +1,59 @@
+package com.sdlcpro.springlens.insight.bean;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.model.bean.BeanRole;
+import com.sdlcpro.springlens.util.ClassInspector;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+/**
+ * Utility methods for inspecting Spring bean metadata, resolving runtime
+ * class details, mapping Spring bean roles, and determining whether a
+ * given bean is an internal SpringLens framework component.
+ */
+public final class BeanInfoUtils {
+
+    private BeanInfoUtils() {
+        throw new UnsupportedOperationException("The BeanInfoUtils is an utility class and cannot be instantiated");
+    }
+
+    /**
+     * Resolves the runtime class of the given bean.
+     *
+     * @param bean the bean instance, may be null
+     * @return the bean's runtime class, or null if the bean is null
+     */
+    public static Class<?> resolveRuntimeClass(Object bean) {
+        return bean != null ? bean.getClass() : null;
+    }
+
+    /**
+     * Resolves the fully qualified runtime type name of the given bean.
+     *
+     * @param bean the bean instance, may be null
+     * @return the bean's fully qualified type name, or null if the bean is null
+     */
+    public static String resolveRuntimeBeanType(Object bean) {
+        return bean != null ? bean.getClass().getTypeName() : null;
+    }
+
+    /**
+     * Resolves the {@link BeanRole} of the given bean name using the provided bean factory.
+     *
+     * @param beanFactory the bean factory to resolve the bean definition from
+     * @param beanName the name of the bean
+     * @return the resolved bean role
+     */
+    public static BeanRole resolveBeanRole(ConfigurableListableBeanFactory beanFactory, String beanName) {
+        return BeanRole.from(beanFactory.getBeanDefinition(beanName).getRole());
+    }
+
+    /**
+     * Checks whether the given bean's class is annotated with {@link SpringLensInternalComponent}.
+     *
+     * @param bean the bean instance, may be null
+     * @return true if the bean is a SpringLens internal component, false otherwise
+     */
+    public static boolean isSpringLensComponent(Object bean) {
+        return bean != null && ClassInspector.hasAnnotation(bean.getClass(), SpringLensInternalComponent.class);
+    }
+}

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/HttpUriProvider.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/HttpUriProvider.java
@@ -1,0 +1,22 @@
+package com.sdlcpro.springlens.insight.http;
+
+/**
+ * A functional interface for retrieving the HTTP URI associated with a target
+ * endpoint or request context.
+ *
+ * <p>Implementations provide URI path patterns that can be used by endpoint
+ * analysis and matching components during framework scanning.</p>
+ *
+ * @since 1.0.0
+ */
+@FunctionalInterface
+public interface HttpUriProvider {
+
+    /**
+     * Returns the HTTP URI path or pattern associated with the target.
+     *
+     * @return the HTTP URI path or pattern
+     */
+    String getHttpUri();
+
+}

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/EndpointInfoCollector.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/EndpointInfoCollector.java
@@ -1,0 +1,37 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.model.http.endpoint.EndpointInfo;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.List;
+
+/**
+ * Strategy interface for extracting {@link EndpointInfo} metadata from a
+ * Spring {@link HandlerMapping} implementation.
+ *
+ * <p>Concrete implementations are responsible for inspecting a specific
+ * {@code HandlerMapping} type (e.g. {@code RequestMappingHandlerMapping})
+ * and collecting endpoint details relevant to that mapping strategy.</p>
+ */
+public interface EndpointInfoCollector {
+
+    /**
+     * Evaluates whether this collector is able to process the given
+     * {@link HandlerMapping} instance.
+     *
+     * @param mapping the handler mapping to evaluate
+     * @return {@code true} if this collector supports the given mapping type,
+     *         {@code false} by default
+     */
+    default boolean supports(HandlerMapping mapping) {
+        return false;
+    }
+
+    /**
+     * Extracts endpoint metadata from the given {@link HandlerMapping}.
+     *
+     * @param mapping the handler mapping to inspect
+     * @return a list of {@link EndpointInfo} snapshots discovered within the mapping
+     */
+    List<EndpointInfo> collect(HandlerMapping mapping);
+}

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeMatcher.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeMatcher.java
@@ -1,0 +1,76 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.matcher.Matcher;
+import com.sdlcpro.springlens.model.http.endpoint.HandlerType;
+import org.springframework.util.CollectionUtils;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * A concrete {@link Matcher} that filters and evaluates candidate HTTP endpoints
+ * based on their designated {@link HandlerType}.
+ *
+ * <p>This matcher integrates into composite evaluation pipelines by consuming
+ * objects that implement {@link HandlerTypeProvider}, allowing framework scanning
+ * components to filter routes based on handler classifications — such as
+ * controller methods, functional WebFlux handlers, or custom/unknown handlers —
+ * in a type-safe manner.</p>
+ *
+ * <p>The configured target set is defensively copied into an immutable
+ * {@link EnumSet} at construction time. A {@code null} or empty input set
+ * yields an empty matching set, which causes every evaluation to fail.</p>
+ *
+ * @param <T> the type of context being matched; must expose its
+ *            {@link HandlerType} via {@link HandlerTypeProvider}
+ * @since 1.0.0
+ * @see HandlerTypeProvider
+ * @see HandlerType
+ * @see Matcher
+ */
+public class HandlerTypeMatcher<T extends HandlerTypeProvider> implements Matcher<T> {
+
+    private final Set<HandlerType> handlerTypes;
+
+    /**
+     * Creates a matcher that accepts contexts whose {@link HandlerType} is
+     * contained in the given set.
+     *
+     * <p>When {@code handlerTypes} is {@code null} or empty, an empty
+     * {@link EnumSet} is used and {@link #matches} will always return
+     * {@code false}. Otherwise the set is copied via
+     * {@link EnumSet#copyOf(java.util.Collection)} to guarantee immutability
+     * of the matcher's internal state.</p>
+     *
+     * @param handlerTypes the handler types to match against; may be
+     *                     {@code null} or empty
+     */
+    public HandlerTypeMatcher(Set<HandlerType> handlerTypes) {
+        this.handlerTypes = CollectionUtils.isEmpty(handlerTypes)
+                ? EnumSet.noneOf(HandlerType.class)
+                : EnumSet.copyOf(handlerTypes);
+    }
+
+    /**
+     * Evaluates whether the given context's handler type is among the
+     * configured target types.
+     *
+     * <p>Returns {@code false} when {@code context} is {@code null}, when
+     * {@link HandlerTypeProvider#getHandlerType()} returns {@code null}, or
+     * when the configured handler-type set is empty. Otherwise returns
+     * whether the candidate's handler type is contained in the matching set.</p>
+     *
+     * @param context the evaluation context providing a {@link HandlerType};
+     *                may be {@code null}
+     * @return {@code true} if the context's handler type is accepted by this
+     *         matcher; {@code false} otherwise
+     */
+    @Override
+    public boolean matches(T context) {
+        if (context == null || context.getHandlerType() == null || CollectionUtils.isEmpty(this.handlerTypes)) {
+            return false;
+        }
+
+        return this.handlerTypes.contains(context.getHandlerType());
+    }
+}

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeProvider.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeProvider.java
@@ -1,0 +1,34 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.model.http.endpoint.HandlerType;
+
+/**
+ * A functional provider interface that exposes the {@link HandlerType} of a
+ * target HTTP endpoint insight tracking object.
+ *
+ * <p>By abstracting the handler classification behind this provider contract,
+ * route-filtering and metadata processing logic is cleanly decoupled from
+ * concrete endpoint models. Consumers can uniformly query whether an endpoint
+ * is backed by a {@linkplain HandlerType#CONTROLLER controller},
+ * {@linkplain HandlerType#FUNCTIONAL functional} handler, or an
+ * {@linkplain HandlerType#UNKNOWN unknown} execution model without depending
+ * on the specific model hierarchy that produced the classification.</p>
+ *
+ * <p>Because this interface declares exactly one abstract method, it is
+ * marked as a {@link FunctionalInterface} and can be expressed as a
+ * lambda expression or method reference.</p>
+ *
+ * @since 1.0.0
+ * @see HandlerType
+ */
+@FunctionalInterface
+public interface HandlerTypeProvider {
+
+    /**
+     * Returns the {@link HandlerType} associated with the target endpoint.
+     *
+     * @return the handler type classification, or {@code null} when the type
+     *         cannot be determined by the provider implementation
+     */
+    HandlerType getHandlerType();
+}

--- a/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/bean/BeanInfoUtilsTest.java
+++ b/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/bean/BeanInfoUtilsTest.java
@@ -1,0 +1,75 @@
+package com.sdlcpro.springlens.insight.bean;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.model.bean.BeanRole;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BeanInfoUtilsTest {
+
+    @SpringLensInternalComponent
+    static class InternalComponent {
+    }
+
+    static class RegularComponent {
+    }
+
+    @Test
+    void resolveRuntimeClassReturnsBeanClass() {
+        RegularComponent bean = new RegularComponent();
+
+        assertThat(BeanInfoUtils.resolveRuntimeClass(bean)).isEqualTo(RegularComponent.class);
+    }
+
+    @Test
+    void resolveRuntimeClassReturnsNullForNullBean() {
+        assertThat(BeanInfoUtils.resolveRuntimeClass(null)).isNull();
+    }
+
+    @Test
+    void resolveRuntimeBeanTypeReturnsTypeName() {
+        RegularComponent bean = new RegularComponent();
+
+        assertThat(BeanInfoUtils.resolveRuntimeBeanType(bean)).isEqualTo(RegularComponent.class.getTypeName());
+    }
+
+    @Test
+    void resolveRuntimeBeanTypeReturnsNullForNullBean() {
+        assertThat(BeanInfoUtils.resolveRuntimeBeanType(null)).isNull();
+    }
+
+    @Test
+    void resolveBeanRoleReturnsRoleFromBeanFactory() {
+        ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
+        BeanDefinition beanDefinition = mock(BeanDefinition.class);
+
+        when(beanFactory.getBeanDefinition("myBean")).thenReturn(beanDefinition);
+        when(beanDefinition.getRole()).thenReturn(BeanRole.ROLE_INFRASTRUCTURE.value());
+
+        assertThat(BeanInfoUtils.resolveBeanRole(beanFactory, "myBean")).isEqualTo(BeanRole.ROLE_INFRASTRUCTURE);
+    }
+
+    @Test
+    void isSpringLensComponentReturnsTrueForAnnotatedBean() {
+        InternalComponent bean = new InternalComponent();
+
+        assertThat(BeanInfoUtils.isSpringLensComponent(bean)).isTrue();
+    }
+
+    @Test
+    void isSpringLensComponentReturnsFalseForRegularBean() {
+        RegularComponent bean = new RegularComponent();
+
+        assertThat(BeanInfoUtils.isSpringLensComponent(bean)).isFalse();
+    }
+
+    @Test
+    void isSpringLensComponentReturnsFalseForNullBean() {
+        assertThat(BeanInfoUtils.isSpringLensComponent(null)).isFalse();
+    }
+}

--- a/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeMatcherTest.java
+++ b/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/endpoint/HandlerTypeMatcherTest.java
@@ -1,0 +1,126 @@
+package com.sdlcpro.springlens.insight.http.endpoint;
+
+import com.sdlcpro.springlens.model.http.endpoint.HandlerType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HandlerTypeMatcherTest {
+
+    private record TestProvider(HandlerType handlerType) implements HandlerTypeProvider {
+
+        @Override
+        public HandlerType getHandlerType() {
+            return handlerType;
+        }
+    }
+
+    @Test
+    @DisplayName("should return false when matcher is created with null set")
+    void shouldReturnFalseForNullSet() {
+        HandlerTypeMatcher<TestProvider> matcher = new HandlerTypeMatcher<>(null);
+        assertFalse(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+    }
+
+    @Test
+    @DisplayName("should return false when matcher is created with empty set")
+    void shouldReturnFalseForEmptySet() {
+        HandlerTypeMatcher<TestProvider> matcher = new HandlerTypeMatcher<>(Set.of());
+        assertFalse(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+    }
+
+    @Test
+    @DisplayName("should return false for null context")
+    void shouldReturnFalseForNullContext() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER));
+        assertFalse(matcher.matches(null));
+    }
+
+    @Test
+    @DisplayName("should return false when context handler type is null")
+    void shouldReturnFalseForNullHandlerType() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER));
+        assertFalse(matcher.matches(new TestProvider(null)));
+    }
+
+    @Test
+    @DisplayName("should return false when handler type does not match")
+    void shouldReturnFalseForNonMatchingHandlerType() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER));
+        assertFalse(matcher.matches(new TestProvider(HandlerType.FUNCTIONAL)));
+        assertFalse(matcher.matches(new TestProvider(HandlerType.UNKNOWN)));
+    }
+
+    @Test
+    @DisplayName("should return true when handler type matches")
+    void shouldReturnTrueForMatchingHandlerType() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER, HandlerType.FUNCTIONAL));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.FUNCTIONAL)));
+    }
+
+    @Test
+    @DisplayName("should match UNKNOWN when included in target set")
+    void shouldMatchUnknownWhenConfigured() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.UNKNOWN));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.UNKNOWN)));
+        assertFalse(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+    }
+
+    @Test
+    @DisplayName("should defensively copy supplied set")
+    void shouldDefensivelyCopyInputSet() {
+        Set<HandlerType> handlerTypes = new HashSet<>();
+        handlerTypes.add(HandlerType.CONTROLLER);
+
+        HandlerTypeMatcher<TestProvider> matcher = new HandlerTypeMatcher<>(handlerTypes);
+
+        handlerTypes.add(HandlerType.FUNCTIONAL);
+
+        assertFalse(matcher.matches(new TestProvider(HandlerType.FUNCTIONAL)));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.CONTROLLER)));
+    }
+
+    @Test
+    @DisplayName("should reject null elements in supplied set")
+    void shouldRejectNullElements() {
+        Set<HandlerType> handlerTypes = new HashSet<>();
+        handlerTypes.add(null);
+
+        assertThrows(
+                NullPointerException.class,
+                () -> new HandlerTypeMatcher<>(handlerTypes)
+        );
+    }
+
+    @Test
+    @DisplayName("should match against second element when first does not match")
+    void shouldMatchAgainstSecondElement() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.of(HandlerType.CONTROLLER, HandlerType.FUNCTIONAL));
+        assertTrue(matcher.matches(new TestProvider(HandlerType.FUNCTIONAL)));
+    }
+
+    @Test
+    @DisplayName("should accept all HandlerType values when configured with allOf")
+    void shouldMatchAllHandlerTypesWhenConfiguredWithAllOf() {
+        HandlerTypeMatcher<TestProvider> matcher =
+                new HandlerTypeMatcher<>(EnumSet.allOf(HandlerType.class));
+
+        for (HandlerType type : HandlerType.values()) {
+            assertTrue(matcher.matches(new TestProvider(type)));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #226
Fixes #224

## #226 — EndpointInfoListener
Adds a `@FunctionalInterface` in `com.sdlcpro.springlens.listener.http.endpoint`
with a single callback method `onEndpointInfoCollect(EndpointInfo)`, following
the same pattern as the existing `BeanDefinitionInfoCollectListener`.

## #224 — BeanInfoUtils
Adds a utility class in `com.sdlcpro.springlens.insight.bean` with:
- `resolveRuntimeClass(Object)`
- `resolveRuntimeBeanType(Object)`
- `resolveBeanRole(ConfigurableListableBeanFactory, String)`
- `isSpringLensComponent(Object)`

Private constructor throwing `UnsupportedOperationException`, per the utility
class convention used elsewhere in the codebase. Unit tests cover class
resolution, bean role lookup, and `@SpringLensInternalComponent` detection,
including null-safety cases.

Note: `resolveBeanRole` doesn't null-check `beanFactory`/`beanName` — kept
consistent with the ticket's own proposed code, since those aren't "bean"
arguments in the same sense as the `Object bean` parameters on the other
methods. Happy to add null checks there too if preferred.