### PR TITLE
Implement HTTP URI path pattern matcher

### DIFF
--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/HttpUriMatcher.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/HttpUriMatcher.java
@@ -1,0 +1,62 @@
+package com.sdlcpro.springlens.insight.http;
+
+import com.sdlcpro.springlens.matcher.Matcher;
+import org.springframework.util.AntPathMatcher;
+
+import java.util.Set;
+
+/**
+ * Matches HTTP URI paths against configured Ant-style path patterns.
+ *
+ * <p>The configured patterns are copied into an immutable set during
+ * construction. A {@code null} or empty set produces a matcher that does not
+ * match any context.</p>
+ *
+ * @param <T> the type of context that provides an HTTP URI
+ * @since 1.0.0
+ * @see HttpUriProvider
+ * @see AntPathMatcher
+ */
+public final class HttpUriMatcher<T extends HttpUriProvider> implements Matcher<T> {
+
+    private static final AntPathMatcher URI_MATCHER = new AntPathMatcher();
+
+    private final Set<String> uriPatterns;
+
+    /**
+     * Creates a matcher for the supplied URI patterns.
+     *
+     * <p>The supplied set is defensively copied using {@link Set#copyOf(java.util.Collection)}.
+     * Passing {@code null} creates a matcher with no patterns.</p>
+     *
+     * @param uriPatterns the Ant-style URI patterns to match; may be {@code null}
+     */
+    public HttpUriMatcher(Set<String> uriPatterns) {
+        this.uriPatterns = uriPatterns == null ? Set.of() : Set.copyOf(uriPatterns);
+    }
+
+    /**
+     * Determines whether the context's HTTP URI matches any configured pattern.
+     *
+     * <p>Returns {@code false} if the context or its URI is {@code null}, or if
+     * no patterns are configured. Otherwise, matching is performed with Spring's
+     * {@link AntPathMatcher}.</p>
+     *
+     * @param context the context providing the candidate HTTP URI; may be {@code null}
+     * @return {@code true} when at least one configured pattern matches the URI;
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean matches(T context) {
+        if (context == null || this.uriPatterns.isEmpty()) {
+            return false;
+        }
+
+        String uri = context.getHttpUri();
+        if (uri == null) {
+            return false;
+        }
+
+        return this.uriPatterns.stream().anyMatch(pattern -> URI_MATCHER.match(pattern, uri));
+    }
+}

--- a/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/HttpUriMatcherTest.java
+++ b/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/HttpUriMatcherTest.java
@@ -1,0 +1,85 @@
+package com.sdlcpro.springlens.insight.http;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HttpUriMatcherTest {
+
+    private record TestProvider(String httpUri) implements HttpUriProvider {
+
+        @Override
+        public String getHttpUri() {
+            return httpUri;
+        }
+    }
+
+    @Test
+    @DisplayName("should match an exact URI")
+    void shouldMatchExactUri() {
+        HttpUriMatcher<TestProvider> matcher = new HttpUriMatcher<>(Set.of("/health"));
+
+        assertTrue(matcher.matches(new TestProvider("/health")));
+    }
+
+    @Test
+    @DisplayName("should match Ant wildcard and URI template patterns")
+    void shouldMatchAntPatterns() {
+        HttpUriMatcher<TestProvider> matcher = new HttpUriMatcher<>(Set.of("/api/**", "/users/{id}"));
+
+        assertTrue(matcher.matches(new TestProvider("/api/v1/orders/42")));
+        assertTrue(matcher.matches(new TestProvider("/users/42")));
+    }
+
+    @Test
+    @DisplayName("should return false for non-matching URIs")
+    void shouldReturnFalseForNonMatchingUri() {
+        HttpUriMatcher<TestProvider> matcher = new HttpUriMatcher<>(Set.of("/api/**", "/users/{id}"));
+
+        assertFalse(matcher.matches(new TestProvider("/admin/users")));
+    }
+
+    @Test
+    @DisplayName("should return false for null context or URI")
+    void shouldReturnFalseForNullContextOrUri() {
+        HttpUriMatcher<TestProvider> matcher = new HttpUriMatcher<>(Set.of("/api/**"));
+
+        assertFalse(matcher.matches(null));
+        assertFalse(matcher.matches(new TestProvider(null)));
+    }
+
+    @Test
+    @DisplayName("should return false when constructed with null or empty patterns")
+    void shouldReturnFalseForNullOrEmptyPatterns() {
+        assertFalse(new HttpUriMatcher<TestProvider>(null).matches(new TestProvider("/api/users")));
+        assertFalse(new HttpUriMatcher<TestProvider>(Set.of()).matches(new TestProvider("/api/users")));
+    }
+
+    @Test
+    @DisplayName("should defensively copy supplied patterns")
+    void shouldDefensivelyCopySuppliedPatterns() {
+        Set<String> patterns = new HashSet<>();
+        patterns.add("/health");
+        HttpUriMatcher<TestProvider> matcher = new HttpUriMatcher<>(patterns);
+
+        patterns.add("/private/**");
+
+        assertTrue(matcher.matches(new TestProvider("/health")));
+        assertFalse(matcher.matches(new TestProvider("/private/metrics")));
+    }
+
+    @Test
+    @DisplayName("should reject null patterns to preserve immutable set semantics")
+    void shouldRejectNullPatterns() {
+        Set<String> patterns = new HashSet<>();
+        patterns.add(null);
+
+        assertThrows(NullPointerException.class, () -> new HttpUriMatcher<>(patterns));
+    }
+}


### PR DESCRIPTION
  Adds HttpUriMatcher to match HTTP request URIs against configured Ant-style path patterns.

  **Changes**

  - Added HttpUriMatcher T extends HttpUriProvider
  - Supports exact paths, wildcards, and URI-template patterns
  - Handles null contexts, null URIs, and empty pattern sets safely
  - Defensively copies configured patterns
  - Added comprehensive unit tests for matching and edge cases

close #251 