### PR TITLE
test(autoconfigure): add test suite for BeanDefinitionInfoStorageConfiguration (#260)

### DIFF
--- a/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/bean/definition/BeanDefinitionInfoStorageConfigurationTest.java
+++ b/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/bean/definition/BeanDefinitionInfoStorageConfigurationTest.java
@@ -1,0 +1,83 @@
+package com.sdlcpro.springlens.autoconfigure.bean.definition;
+
+import com.sdlcpro.springlens.repository.bean.BeanDefinitionInfoRepository;
+import com.sdlcpro.springlens.storage.bean.definition.BeanDefinitionInfoPersistenceHandler;
+import com.sdlcpro.springlens.storage.bean.definition.InMemoryBeanDefinitionInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class BeanDefinitionInfoStorageConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(BeanDefinitionInfoStorageConfiguration.class);
+
+    @Test
+    void registersStorageBeansWhenInMemoryRepositoryClassIsPresent() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(BeanDefinitionInfoStorageConfiguration.class);
+            assertThat(context).hasSingleBean(BeanDefinitionInfoRepository.class);
+            assertThat(context).hasSingleBean(InMemoryBeanDefinitionInfoRepository.class);
+            assertThat(context).hasSingleBean(BeanDefinitionInfoPersistenceHandler.class);
+            assertThat(context.getBean(BeanDefinitionInfoRepository.class))
+                    .isInstanceOf(InMemoryBeanDefinitionInfoRepository.class);
+        });
+    }
+
+    @Test
+    void backsOffWhenInMemoryRepositoryClassIsAbsent() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(InMemoryBeanDefinitionInfoRepository.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoStorageConfiguration.class);
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoRepository.class);
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoPersistenceHandler.class);
+                });
+    }
+
+    @Test
+    void backsOffDefaultRepositoryWhenCustomRepositoryIsDefined() {
+        BeanDefinitionInfoRepository customRepository = mock(BeanDefinitionInfoRepository.class);
+
+        contextRunner
+                .withBean(BeanDefinitionInfoRepository.class, () -> customRepository)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(BeanDefinitionInfoRepository.class);
+                    assertThat(context).doesNotHaveBean(InMemoryBeanDefinitionInfoRepository.class);
+                    assertThat(context.getBean(BeanDefinitionInfoRepository.class)).isSameAs(customRepository);
+                    assertThat(context).hasSingleBean(BeanDefinitionInfoPersistenceHandler.class);
+                });
+    }
+
+    @Test
+    void backsOffDefaultPersistenceHandlerWhenCustomHandlerIsDefined() {
+        BeanDefinitionInfoRepository repository = new InMemoryBeanDefinitionInfoRepository();
+        BeanDefinitionInfoPersistenceHandler customHandler =
+                new BeanDefinitionInfoPersistenceHandler(repository);
+
+        contextRunner
+                .withBean(BeanDefinitionInfoPersistenceHandler.class, () -> customHandler)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(BeanDefinitionInfoRepository.class);
+                    assertThat(context).hasSingleBean(BeanDefinitionInfoPersistenceHandler.class);
+                    assertThat(context.getBean(BeanDefinitionInfoPersistenceHandler.class))
+                            .isSameAs(customHandler);
+                });
+    }
+
+    @Test
+    void doesNotRegisterStorageBeansWhenFeatureIsDisabled() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(SpringLensBeanDefinitionInfoAutoConfiguration.class))
+                .withPropertyValues("spring.lens.bean.definition.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoStorageConfiguration.class);
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoRepository.class);
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoPersistenceHandler.class);
+                });
+    }
+}


### PR DESCRIPTION
## Summary
Adds a comprehensive JUnit 5 test suite (`BeanDefinitionInfoStorageConfigurationTest`) for `BeanDefinitionInfoStorageConfiguration` in `spring-lens-autoconfigure`. 

This verifies that storage components and repository beans for bean definition information are conditionally configured only under appropriate Classpath, Bean Presence, and Property conditions.

## Changes Made
- Added `BeanDefinitionInfoStorageConfigurationTest` to `com.sdlcpro.springlens.autoconfigure.bean.definition`.
- Utilized Spring Boot's `ApplicationContextRunner` and `FilteredClassLoader` to validate auto-configuration loading and back-off mechanics.
- Added test coverage for custom bean override behavior and property toggle controls.

## Test Cases Covered
1. **Repository Class Present:** Verifies that both `BeanDefinitionInfoStorageConfiguration` and `InMemoryBeanDefinitionInfoRepository` are loaded when present on the classpath.
2. **Missing Repository Class (`FilteredClassLoader`):** Verifies `@ConditionalOnClass` back-off behavior when `InMemoryBeanDefinitionInfoRepository` is excluded from the classpath.
3. **Custom Repository Override:** Verifies `@ConditionalOnMissingBean` behavior where a user-defined `BeanDefinitionInfoRepository` replaces the default in-memory repository while keeping required handlers active.
4. **Custom Persistence Handler Override:** Verifies that a user-defined `BeanDefinitionInfoPersistenceHandler` is preserved without conflicting with default storage configurations.
5. **Disabled Property Toggle:** Verifies configuration back-off when `spring.lens.bean.definition.enabled=false`.

## Related Issue
Closes #260
