### PR TITLE
test(autoconfigure): add BeanDefinitionInfoHttpExposureConfigurationTest suite (#259)

### DIFF
--- a/spring-lens-autoconfigure/pom.xml
+++ b/spring-lens-autoconfigure/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/bean/definition/BeanDefinitionInfoHttpExposureConfigurationTest.java
+++ b/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/bean/definition/BeanDefinitionInfoHttpExposureConfigurationTest.java
@@ -1,0 +1,93 @@
+package com.sdlcpro.springlens.autoconfigure.bean.definition;
+
+import com.sdlcpro.springlens.exposure.bean.BeanDefinitionInfoRestController;
+import com.sdlcpro.springlens.repository.bean.BeanDefinitionInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class BeanDefinitionInfoHttpExposureConfigurationTest {
+
+    private final WebApplicationContextRunner servletRunner = new WebApplicationContextRunner()
+            .withUserConfiguration(BeanDefinitionInfoHttpExposureConfiguration.class);
+
+    private final ApplicationContextRunner nonWebRunner = new ApplicationContextRunner()
+            .withUserConfiguration(BeanDefinitionInfoHttpExposureConfiguration.class);
+
+    private final ReactiveWebApplicationContextRunner reactiveRunner = new ReactiveWebApplicationContextRunner()
+            .withUserConfiguration(BeanDefinitionInfoHttpExposureConfiguration.class);
+
+    @Test
+    void registersRestControllerInServletWebApplicationWhenRepositoryIsPresent() {
+        BeanDefinitionInfoRepository repository = mock(BeanDefinitionInfoRepository.class);
+
+        servletRunner
+                .withBean(BeanDefinitionInfoRepository.class, () -> repository)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(BeanDefinitionInfoHttpExposureConfiguration.class);
+                    assertThat(context).hasSingleBean(BeanDefinitionInfoRestController.class);
+                });
+    }
+
+    @Test
+    void doesNotRegisterRestControllerWhenRepositoryBeanIsMissing() {
+        servletRunner.run(context -> {
+            assertThat(context).hasSingleBean(BeanDefinitionInfoHttpExposureConfiguration.class);
+            assertThat(context).doesNotHaveBean(BeanDefinitionInfoRestController.class);
+        });
+    }
+
+    @Test
+    void backsOffInNonWebApplicationContext() {
+        BeanDefinitionInfoRepository repository = mock(BeanDefinitionInfoRepository.class);
+
+        nonWebRunner
+                .withBean(BeanDefinitionInfoRepository.class, () -> repository)
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoHttpExposureConfiguration.class);
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoRestController.class);
+                });
+    }
+
+    @Test
+    void backsOffInReactiveWebApplicationContext() {
+        BeanDefinitionInfoRepository repository = mock(BeanDefinitionInfoRepository.class);
+
+        reactiveRunner
+                .withBean(BeanDefinitionInfoRepository.class, () -> repository)
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoHttpExposureConfiguration.class);
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoRestController.class);
+                });
+    }
+
+    @Test
+    void backsOffWhenRestControllerClassIsAbsent() {
+        BeanDefinitionInfoRepository repository = mock(BeanDefinitionInfoRepository.class);
+
+        servletRunner
+                .withClassLoader(new FilteredClassLoader(BeanDefinitionInfoRestController.class))
+                .withBean(BeanDefinitionInfoRepository.class, () -> repository)
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoHttpExposureConfiguration.class);
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoRestController.class);
+                });
+    }
+
+    @Test
+    void doesNotRegisterExposureBeansWhenFeatureIsDisabled() {
+        new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(SpringLensBeanDefinitionInfoAutoConfiguration.class))
+                .withPropertyValues("spring.lens.bean.definition.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoHttpExposureConfiguration.class);
+                    assertThat(context).doesNotHaveBean(BeanDefinitionInfoRestController.class);
+                });
+    }
+}


### PR DESCRIPTION
## Summary
Adds a comprehensive JUnit 5 test suite (`BeanDefinitionInfoHttpExposureConfigurationTest`) for `BeanDefinitionInfoHttpExposureConfiguration` in `spring-lens-autoconfigure`. 

This verifies that HTTP exposure for bean definition information is conditionally configured only under appropriate Web Application, Repository, and Classpath conditions, following the pattern established in #260.

## Changes Made
- Added `BeanDefinitionInfoHttpExposureConfigurationTest` to `com.sdlcpro.springlens.autoconfigure.bean.definition`.
- Utilized `WebApplicationContextRunner`, `ReactiveWebApplicationContextRunner`, and `ApplicationContextRunner` to test context-specific loading behaviors.
- Added `spring-webflux` as a `test` scoped dependency to support reactive context verification.

## Test Cases Covered (6/6 Passing)
1. **Servlet Web Context + Repository present:** Verifies that both the configuration and `BeanDefinitionInfoRestController` are loaded.
2. **Servlet Web Context without Repository:** Verifies `@ConditionalOnBean` back-off behavior (config loads, controller backs off).
3. **Non-Web Context (`ApplicationContextRunner`):** Verifies configuration backs off in standard non-web environments.
4. **Reactive Web Context (`ReactiveWebApplicationContextRunner`):** Verifies configuration backs off in WebFlux environments.
5. **Missing Class Condition (`FilteredClassLoader`):** Verifies back-off when `BeanDefinitionInfoRestController` is absent from the classpath.
6. **Disabled Property Toggle:** Verifies back-off when `spring.lens.bean.definition.enabled=false`.

## Related Issue
Closes #259