### PR TITLE
feat: add bean definition summary model

### DIFF
--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/bean/LoadingMode.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/bean/LoadingMode.java
@@ -1,0 +1,17 @@
+package com.sdlcpro.springlens.model.bean;
+
+/**
+ * Represents the loading strategy used to initialize a Spring bean.
+ */
+public enum LoadingMode {
+
+    /**
+     * The bean is initialized eagerly during application context startup.
+     */
+    EAGER,
+
+    /**
+     * The bean is initialized lazily when it is first requested.
+     */
+    LAZY
+}

--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/bean/definition/BeanDefinitionSummary.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/bean/definition/BeanDefinitionSummary.java
@@ -1,0 +1,68 @@
+package com.sdlcpro.springlens.model.bean.definition;
+
+import com.sdlcpro.springlens.model.bean.BeanRole;
+import com.sdlcpro.springlens.model.bean.LoadingMode;
+import com.sdlcpro.springlens.util.Preconditions;
+
+import java.util.Map;
+
+/**
+ * Immutable summary of bean definition metrics across Spring application
+ * contexts.
+ *
+ * <p>The summary contains distributions of bean definitions by application
+ * context, scope, role, and loading mode, together with the total number of
+ * bean definitions.</p>
+ *
+ * @param contextDistribution distribution of bean definitions by context
+ * @param scopeDistribution distribution of bean definitions by scope
+ * @param roleDistribution distribution of bean definitions by role
+ * @param loadingModeDistribution distribution of bean definitions by loading mode
+ * @param totalBeanDefinitions total number of bean definitions
+ */
+public record BeanDefinitionSummary(
+        Map<String, Integer> contextDistribution,
+        Map<String, Integer> scopeDistribution,
+        Map<BeanRole, Integer> roleDistribution,
+        Map<LoadingMode, Integer> loadingModeDistribution,
+        long totalBeanDefinitions
+) {
+
+    public BeanDefinitionSummary {
+        contextDistribution = contextDistribution == null
+                ? Map.of()
+                : Map.copyOf(contextDistribution);
+
+        scopeDistribution = scopeDistribution == null
+                ? Map.of()
+                : Map.copyOf(scopeDistribution);
+
+        roleDistribution = roleDistribution == null
+                ? Map.of()
+                : Map.copyOf(roleDistribution);
+
+        loadingModeDistribution = loadingModeDistribution == null
+                ? Map.of()
+                : Map.copyOf(loadingModeDistribution);
+
+        Preconditions.isTrue(
+                totalBeanDefinitions >= 0,
+                "Total bean definition count must not be negative value"
+        );
+    }
+
+    /**
+     * Creates an empty bean definition summary.
+     *
+     * @return an empty summary with zero total bean definitions
+     */
+    public static BeanDefinitionSummary empty() {
+        return new BeanDefinitionSummary(
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                0L
+        );
+    }
+}

--- a/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/bean/definition/BeanDefinitionSummaryTest.java
+++ b/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/bean/definition/BeanDefinitionSummaryTest.java
@@ -1,0 +1,121 @@
+package com.sdlcpro.springlens.model.bean.definition;
+
+import com.sdlcpro.springlens.model.bean.BeanRole;
+import com.sdlcpro.springlens.model.bean.LoadingMode;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BeanDefinitionSummaryTest {
+
+    @Test
+    void shouldRejectNegativeTotalBeanDefinitions() {
+        assertThatThrownBy(() -> new BeanDefinitionSummary(
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                -1L
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Total bean definition count must not be negative value");
+    }
+
+    @Test
+    void shouldDefensivelyCopyDistributionMaps() {
+        Map<String, Integer> contexts = new HashMap<>();
+        contexts.put("application", 5);
+
+        Map<String, Integer> scopes = new HashMap<>();
+        scopes.put("singleton", 5);
+
+        Map<BeanRole, Integer> roles = new HashMap<>();
+        roles.put(BeanRole.ROLE_APPLICATION, 5);
+
+        Map<LoadingMode, Integer> loadingModes = new HashMap<>();
+        loadingModes.put(LoadingMode.EAGER, 5);
+
+        BeanDefinitionSummary summary = new BeanDefinitionSummary(
+                contexts,
+                scopes,
+                roles,
+                loadingModes,
+                5L
+        );
+
+        contexts.put("another-context", 10);
+        scopes.put("prototype", 10);
+        roles.put(BeanRole.ROLE_INFRASTRUCTURE, 10);
+        loadingModes.put(LoadingMode.LAZY, 10);
+
+        assertThat(summary.contextDistribution())
+                .containsExactly(Map.entry("application", 5));
+
+        assertThat(summary.scopeDistribution())
+                .containsExactly(Map.entry("singleton", 5));
+
+        assertThat(summary.roleDistribution())
+                .containsExactly(Map.entry(BeanRole.ROLE_APPLICATION, 5));
+
+        assertThat(summary.loadingModeDistribution())
+                .containsExactly(Map.entry(LoadingMode.EAGER, 5));
+    }
+
+    @Test
+    void shouldExposeImmutableDistributionMaps() {
+        BeanDefinitionSummary summary = new BeanDefinitionSummary(
+                Map.of("application", 5),
+                Map.of("singleton", 5),
+                Map.of(BeanRole.ROLE_APPLICATION, 5),
+                Map.of(LoadingMode.EAGER, 5),
+                5L
+        );
+
+        assertThatThrownBy(() ->
+                summary.contextDistribution().put("another", 1))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(() ->
+                summary.scopeDistribution().put("prototype", 1))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(() ->
+                summary.roleDistribution().put(BeanRole.ROLE_INFRASTRUCTURE, 1))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(() ->
+                summary.loadingModeDistribution().put(LoadingMode.LAZY, 1))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldTreatNullDistributionMapsAsEmpty() {
+        BeanDefinitionSummary summary = new BeanDefinitionSummary(
+                null,
+                null,
+                null,
+                null,
+                0L
+        );
+
+        assertThat(summary.contextDistribution()).isEmpty();
+        assertThat(summary.scopeDistribution()).isEmpty();
+        assertThat(summary.roleDistribution()).isEmpty();
+        assertThat(summary.loadingModeDistribution()).isEmpty();
+    }
+
+    @Test
+    void emptyShouldReturnZeroedSummary() {
+        BeanDefinitionSummary summary = BeanDefinitionSummary.empty();
+
+        assertThat(summary.contextDistribution()).isEmpty();
+        assertThat(summary.scopeDistribution()).isEmpty();
+        assertThat(summary.roleDistribution()).isEmpty();
+        assertThat(summary.loadingModeDistribution()).isEmpty();
+        assertThat(summary.totalBeanDefinitions()).isZero();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `LoadingMode` enum for eager and lazy bean initialization.
- Add immutable `BeanDefinitionSummary` record.
- Add validation for non-negative bean definition totals.
- Add defensive copying and null-safe handling for distribution maps.
- Add unit tests covering validation, immutability, null handling, and empty summaries.

## Testing

- `mvn -pl spring-lens-core test`
- `BeanDefinitionSummaryTest`: 5 tests passed