### PR TITLE
Add ConditionEvaluationCollectionContext

### DIFF
--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/ConditionEvaluationCollectionContext.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/ConditionEvaluationCollectionContext.java
@@ -1,0 +1,10 @@
+package com.sdlcpro.springlens.insight.bean;
+
+import com.sdlcpro.springlens.insight.support.provider.ClassNameProvider;
+
+public record ConditionEvaluationCollectionContext(String className) implements ClassNameProvider {
+    @Override
+    public String getClassName(){
+        return this.className;
+    }
+}

--- a/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/bean/ConditionEvaluationCollectionContextTest.java
+++ b/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/bean/ConditionEvaluationCollectionContextTest.java
@@ -1,0 +1,17 @@
+package com.sdlcpro.springlens.insight.bean;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+class ConditionEvaluationCollectionContextTest {
+    @Test
+    void shouldReturnClassName(){
+        String className = "com.example.TestClass";
+
+        ConditionEvaluationCollectionContext context = new ConditionEvaluationCollectionContext(className);
+
+        assertEquals(className, context.getClassName());
+    }
+}


### PR DESCRIPTION
## Summary
-Added "ConditionEvaluationCollectionContext" as Java record.
-Implemented the "ClassNameProvider" interface.
-Added "getClassName()" to return the provided class name.
-Added unit tests to verify class name extraction.