### PR TITLE
Add BeanInstanceInfoEventStream Interface

### DIFF
--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/BeanInstanceInfoEventStream.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/BeanInstanceInfoEventStream.java
@@ -1,0 +1,23 @@
+package com.sdlcpro.springlens.insight.bean;
+
+import com.sdlcpro.springlens.model.bean.instance.BeanInstanceInfo;
+import com.sdlcpro.springlens.listener.bean.BeanInstanceInfoCollectListener;
+
+/**
+ * Defines a reactive/pub-sub contract for publishing collected BeanInstanceInfo models
+ * and managing listener subscriptions.
+ */
+public interface BeanInstanceInfoEventStream {
+    /**
+     * Broadcasts a collected BeanInstanceInfo entity to active stream listeners.
+     *
+     * @param beanInstanceInfo the collected bean instance metadata to broadcast
+     */
+    void publish(BeanInstanceInfo beanInstanceInfo);
+    /**
+     * Registers a listener to receive BeanInstanceInfo events.
+     *
+     * @param listener the callback to register for receiving subsequent bean instance events
+     */
+    void subscribe(BeanInstanceInfoCollectListener listener);
+}


### PR DESCRIPTION
## Summary
Introduces the BeanInstanceInfoEventStream interface incom.sdlcpro.springlens.insight.bean.instance, defining the reactivepublish/subscribe contract for broadcasting BeanInstanceInfo models.

## Related Issue
Closes #307 

## Changes
- Added BeanInstanceInfoEventStream.java with:
  1. publish(BeanInstanceInfo) method signature
  1. subscribe(BeanInstanceInfoCollectListener) method signature
  1. Full JavaDoc on the interface and both methods
## Checklist
 * [x] File placed in correct package
 * [x] Imports for BeanInstanceInfo and BeanInstanceInfoCollectListener resolved
 * [x] JavaDoc added to interface and both methods
 * [x] Builds locally without errors
