### PR TITLE
feat: introduce BeanProxyInfoInspector interface

### DIFF
--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/inspector/BeanProxyInfoInspector.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/inspector/BeanProxyInfoInspector.java
@@ -1,0 +1,18 @@
+package com.sdlcpro.springlens.inspector;
+
+import com.sdlcpro.springlens.model.bean.instance.BeanInstanceProxyInfo;
+
+/**
+ * Inspects Spring bean instances to extract proxy metadata.
+ */
+public interface BeanProxyInfoInspector {
+
+    /**
+     * Inspects the specified bean and extracts its proxy metadata.
+     *
+     * @param beanName the name of the Spring bean to inspect
+     * @return proxy information for the bean, or {@code null} if the bean
+     *         does not exist or is not proxied
+     */
+    BeanInstanceProxyInfo inspectBeanInstanceProxyInfo(String beanName);
+}


### PR DESCRIPTION
## Summary

- Introduce the `BeanProxyInfoInspector` interface in the core module.
- Define the `inspectBeanInstanceProxyInfo(String beanName)` contract.
- Add JavaDoc for the interface and method.

## Validation

- `mvn test` passed across all modules.
- All tests passed successfully.

Closes #306