### PR TITLE
Implement ConditionEvaluationInfoPersistenceHandler persistence listener

### DIFF
--- a/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/bean/condition/ConditionEvaluationInfoPersistenceHandler.java
+++ b/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/bean/condition/ConditionEvaluationInfoPersistenceHandler.java
@@ -1,0 +1,43 @@
+package com.sdlcpro.springlens.storage.bean.condition;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.listener.bean.ConditionEvaluationInfoCollectListener;
+import com.sdlcpro.springlens.model.bean.condition.ConditionEvaluationInfo;
+import com.sdlcpro.springlens.repository.bean.ConditionEvaluationInfoRepository;
+
+/**
+ * Persistence handler that bridges collected {@link ConditionEvaluationInfo} events
+ * with storage
+ * <p>
+ * Listens for {@link ConditionEvaluationInfo} events via
+ * {@link ConditionEvaluationInfoCollectListener} and persists them using
+ * {@link ConditionEvaluationInfoRepository}.
+ */
+@SpringLensInternalComponent
+public class ConditionEvaluationInfoPersistenceHandler implements ConditionEvaluationInfoCollectListener {
+
+    private final ConditionEvaluationInfoRepository conditionEvaluationInfoRepository;
+
+    /**
+     * Creates a new {@link ConditionEvaluationInfoPersistenceHandler}
+     * with the given {@code conditionEvaluationInfoRepository}
+     *
+     * @param conditionEvaluationInfoRepository the repository used to save {@code conditionEvaluationInfo}
+     */
+    public ConditionEvaluationInfoPersistenceHandler(ConditionEvaluationInfoRepository conditionEvaluationInfoRepository) {
+        this.conditionEvaluationInfoRepository = conditionEvaluationInfoRepository;
+    }
+
+    /**
+     * Save the {@code conditionEvaluationInfo} to the
+     * {@link ConditionEvaluationInfoRepository} when it is not null
+     *
+     * @param conditionEvaluationInfo the collected condition evaluation info, ignored when null
+     */
+    @Override
+    public void onConditionEvaluationInfoCollect(ConditionEvaluationInfo conditionEvaluationInfo) {
+        if(conditionEvaluationInfo != null) {
+            this.conditionEvaluationInfoRepository.save(conditionEvaluationInfo);
+        }
+    }
+}

--- a/spring-lens-storage/src/test/java/com/sdlcpro/springlens/storage/bean/condition/ConditionEvaluationInfoPersistenceHandlerTest.java
+++ b/spring-lens-storage/src/test/java/com/sdlcpro/springlens/storage/bean/condition/ConditionEvaluationInfoPersistenceHandlerTest.java
@@ -1,0 +1,47 @@
+package com.sdlcpro.springlens.storage.bean.condition;
+
+
+import com.sdlcpro.springlens.model.bean.condition.ConditionEvaluationInfo;
+import com.sdlcpro.springlens.model.bean.condition.ConditionOutcome;
+import com.sdlcpro.springlens.repository.bean.ConditionEvaluationInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class ConditionEvaluationInfoPersistenceHandlerTest {
+
+    @Mock
+    private ConditionEvaluationInfoRepository conditionEvaluationInfoRepository;
+
+    @InjectMocks
+    private ConditionEvaluationInfoPersistenceHandler persistenceHandler;
+
+    @Test
+    void shouldSaveConditionEvaluationInfoWhenCollected() {
+        ConditionEvaluationInfo conditionEvaluationInfo = new ConditionEvaluationInfo(
+                "applicationContext",
+                "com.example.MyAutoConfiguration",
+                ConditionOutcome.MATCHED,
+                List.of()
+        );
+
+        persistenceHandler.onConditionEvaluationInfoCollect(conditionEvaluationInfo);
+
+        verify(conditionEvaluationInfoRepository).save(conditionEvaluationInfo);
+    }
+
+    @Test
+    void shouldNotSaveWhenConditionEvaluationInfoIsNull() {
+        persistenceHandler.onConditionEvaluationInfoCollect(null);
+
+        verifyNoInteractions(conditionEvaluationInfoRepository);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ConditionEvaluationInfoPersistenceHandler` in `com.sdlcpro.springlens.storage.bean.condition`, implementing `ConditionEvaluationInfoCollectListener` and delegating persistence to the injected `ConditionEvaluationInfoRepository`
- Annotate with `@SpringLensInternalComponent` so it auto-registers as a Spring bean
- Null-safe: `onConditionEvaluationInfoCollect` only calls `save(...)` when the incoming `ConditionEvaluationInfo` is non-null

## Test plan
- Added `ConditionEvaluationInfoPersistenceHandlerTest` covering:
  - `save(...)` is invoked once when a valid `ConditionEvaluationInfo` is collected
  - repository has no interactions when `null` is collected
- All tests pass locally

Closes #298