### PR TITLE
Add ProxyType enum and update BeanInstanceProxyInfo validation

### DIFF
--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/bean/ProxyType.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/bean/ProxyType.java
@@ -1,0 +1,5 @@
+package com.sdlcpro.springlens.model.bean;
+
+public enum ProxyType {
+    CGLIB, JDK_DYNAMIC, UNKNOWN
+}

--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/bean/instance/BeanInstanceProxyInfo.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/bean/instance/BeanInstanceProxyInfo.java
@@ -1,5 +1,8 @@
 package com.sdlcpro.springlens.model.bean.instance;
 
+import com.sdlcpro.springlens.model.bean.ProxyType;
+import com.sdlcpro.springlens.util.Preconditions;
+
 import java.util.List;
 
 /**
@@ -10,6 +13,12 @@ public record BeanInstanceProxyInfo(
         String targetClass,
         List<String> advices,
         List<String> proxiedInterfaces,
-        boolean adviceFrozen
+        boolean adviceFrozen,
+        ProxyType proxyType
 ) {
+    public BeanInstanceProxyInfo {
+        Preconditions.notNull(proxyType, "Proxy type must not be null");
+        advices = advices == null ? List.of() : List.copyOf(advices);
+        proxiedInterfaces = proxiedInterfaces == null ? List.of() : List.copyOf(proxiedInterfaces);
+    }
 }

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/instance/DefaultBeanProxyInfoInspector.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/instance/DefaultBeanProxyInfoInspector.java
@@ -2,6 +2,7 @@ package com.sdlcpro.springlens.insight.bean.instance;
 
 import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
 import com.sdlcpro.springlens.inspector.BeanProxyInfoInspector;
+import com.sdlcpro.springlens.model.bean.ProxyType;
 import com.sdlcpro.springlens.model.bean.instance.BeanInstanceProxyInfo;
 import com.sdlcpro.springlens.util.Preconditions;
 import org.springframework.aop.Advisor;
@@ -60,7 +61,8 @@ public class DefaultBeanProxyInfoInspector implements BeanProxyInfoInspector {
                 targetClass,
                 List.copyOf(advices),
                 List.copyOf(proxiedInterfaces),
-                advised.isFrozen()
+                advised.isFrozen(),
+                ProxyType.UNKNOWN
         );
     }
 }


### PR DESCRIPTION
- Add ProxyType enum with CGLIB, JDK_DYNAMIC, UNKNOWN constants
- Update BeanInstanceProxyInfo record with proxyType field
- Add defensive List.copyOf() for advices and proxiedInterfaces
- Add Preconditions.notNull validation for proxyType
- Update DefaultBeanProxyInfoInspector to pass ProxyType.UNKNOWN