### PR TITLE
Implement InMemoryBeanInstanceInfoRepository storage component

### DIFF
--- a/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/bean/instance/InMemoryBeanInstanceInfoRepository.java
+++ b/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/bean/instance/InMemoryBeanInstanceInfoRepository.java
@@ -1,0 +1,112 @@
+package com.sdlcpro.springlens.storage.bean.instance;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.model.bean.BeanInfoCompositeKey;
+import com.sdlcpro.springlens.model.bean.instance.BeanInstanceInfo;
+import com.sdlcpro.springlens.model.bean.instance.BeanInstanceProxyInfo;
+import com.sdlcpro.springlens.query.Filter;
+import com.sdlcpro.springlens.query.PageRequest;
+import com.sdlcpro.springlens.query.PageResponse;
+import com.sdlcpro.springlens.repository.bean.BeanInstanceInfoRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * In-memory storage implementation of {@link BeanInstanceInfoRepository}.
+ * <p>
+ * This class serves as the initial component implementation, stubbed with
+ * {@link UnsupportedOperationException} for pending method implementations.
+ */
+@SpringLensInternalComponent
+public class InMemoryBeanInstanceInfoRepository implements BeanInstanceInfoRepository {
+
+    /**
+     * Returns proxy metadata for the bean instance matching the given key.
+     *
+     * @param key context ID + bean name identifying the instance
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public BeanInstanceProxyInfo findProxyInfoById(BeanInfoCompositeKey key) {
+        throw new UnsupportedOperationException("findProxyInfoById is not yet implemented.");
+    }
+
+    /**
+     * Returns a page of {@link BeanInstanceInfo} entries matching the given page request.
+     *
+     * @param pageRequest the pagination parameters
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public PageResponse<BeanInstanceInfo> findAll(PageRequest pageRequest) {
+        throw new UnsupportedOperationException("findAll is not yet implemented.");
+    }
+
+    /**
+     * Returns a filtered page of {@link BeanInstanceInfo} entries matching the given
+     * filter and page request.
+     *
+     * @param filter      the filter criteria to apply
+     * @param pageRequest the pagination parameters
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public PageResponse<BeanInstanceInfo> findAll(Filter filter, PageRequest pageRequest) {
+        throw new UnsupportedOperationException("findAll is not yet implemented.");
+    }
+
+    /**
+     * Persists the given {@link BeanInstanceInfo} entity.
+     *
+     * @param entity the bean instance info to persist
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public void save(BeanInstanceInfo entity) {
+        throw new UnsupportedOperationException("save is not yet implemented.");
+    }
+
+    /**
+     * Returns all stored {@link BeanInstanceInfo} entries.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public List<BeanInstanceInfo> findAll() {
+        throw new UnsupportedOperationException("findAll is not yet implemented.");
+    }
+
+    /**
+     * Returns the {@link BeanInstanceInfo} matching the given key, if present.
+     *
+     * @param beanInfoCompositeKey context ID + bean name identifying the instance
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public Optional<BeanInstanceInfo> findById(BeanInfoCompositeKey beanInfoCompositeKey) {
+        throw new UnsupportedOperationException("findById is not yet implemented.");
+    }
+
+    /**
+     * Deletes the {@link BeanInstanceInfo} matching the given key.
+     *
+     * @param beanInfoCompositeKey context ID + bean name identifying the instance
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public void deleteById(BeanInfoCompositeKey beanInfoCompositeKey) {
+        throw new UnsupportedOperationException("deleteById is not yet implemented.");
+    }
+
+    /**
+     * Returns the total number of stored {@link BeanInstanceInfo} entries.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public long count() {
+        throw new UnsupportedOperationException("count is not yet implemented.");
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add `InMemoryBeanInstanceInfoRepository` in `com.sdlcpro.springlens.storage.bean.instance`, implementing the `BeanInstanceInfoRepository` contract (including inherited `PageableRepository`/`Repository` operations and `findProxyInfoById`)
- Annotate with `@SpringLensInternalComponent` so it auto-registers as a Spring bean
- All methods currently throw `UnsupportedOperationException` with a descriptive message, as an initial scaffold pending actual in-memory storage logic
- Note: the issue's proposed code used Spring Data-style `Page`/`Pageable` signatures, which don't match this repo's actual `PageableRepository` contract (`PageResponse`/`PageRequest`/`Filter`); implemented against the real interface instead

Closes #301