### PR TITLE
fix: exclude tool-internal components with ComponentMatcher

### DIFF
--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/BeanInfoUtils.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/BeanInfoUtils.java
@@ -1,7 +1,6 @@
 package com.sdlcpro.springlens.insight.bean;
 
 import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
-import com.sdlcpro.springlens.insight.http.endpoint.ToolInternalEndpointMatcher;
 import com.sdlcpro.springlens.insight.support.matcher.ClassNameMatcher;
 import com.sdlcpro.springlens.insight.support.matcher.PackageMatcher;
 import com.sdlcpro.springlens.matcher.CompositeMatcher;
@@ -138,7 +137,7 @@ public final class BeanInfoUtils {
         matcher.addExcludeMatcher(new PackageMatcher<>(settings.excludePackagePatterns()));
 
         if (!settings.includeToolInternal()) {
-            matcher.addExcludeMatcher(new ToolInternalEndpointMatcher<>());
+            matcher.addExcludeMatcher(new ToolInternalComponentMatcher<>());
         }
 
         return matcher;

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/ToolInternalComponentMatcher.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/bean/ToolInternalComponentMatcher.java
@@ -1,0 +1,28 @@
+package com.sdlcpro.springlens.insight.bean;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.insight.support.matcher.AnnotatedClassMatcher;
+import com.sdlcpro.springlens.insight.support.provider.ClassProvider;
+
+import java.util.Set;
+
+/**
+ * Matches Spring Lens internal tool components annotated with
+ * {@link SpringLensInternalComponent}.
+ *
+ * <p>Used when collecting bean definitions so framework-owned beans can be
+ * excluded without treating only HTTP endpoints as internal.</p>
+ *
+ * @param <T> the type of context being matched; it must provide a class
+ * @since 1.0.0
+ */
+public class ToolInternalComponentMatcher<T extends ClassProvider> extends AnnotatedClassMatcher<T> {
+
+    /**
+     * Creates a matcher that recognizes classes annotated with
+     * {@link SpringLensInternalComponent}.
+     */
+    public ToolInternalComponentMatcher() {
+        super(Set.of(SpringLensInternalComponent.class));
+    }
+}


### PR DESCRIPTION
## Summary

Fix incorrect matcher registration in createCollectionMatcher.

## Changes

- Use ToolInternalComponentMatcher for @SpringLensInternalComponent
- Add matcher class parallel to ToolInternalEndpointMatcher

Fixes #331
