### PR TITLE
#29 Implement Core Request Monitoring (HTTP request/response capture)

### DIFF
--- a/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoCollectorConfiguration.java
+++ b/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoCollectorConfiguration.java
@@ -1,0 +1,54 @@
+package com.sdlcpro.springlens.autoconfigure.http.request;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.insight.http.request.HttpRequestCollectorSettings;
+import com.sdlcpro.springlens.insight.http.request.HttpRequestInfoCollectorFilter;
+import com.sdlcpro.springlens.listener.http.request.HttpRequestInfoCollectListener;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
+import org.springframework.core.Ordered;
+
+import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+
+@SpringLensInternalComponent
+@Configuration(proxyBeanMethods = false)
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+@ConditionalOnWebApplication(type = Type.SERVLET)
+class HttpRequestInfoCollectorConfiguration {
+
+    @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    public HttpRequestInfoCollectorFilter httpRequestInfoCollectorFilter(
+            SpringLensHttpRequestProperties properties,
+            ObjectProvider<HttpRequestInfoCollectListener> httpRequestInfoCollectListenerProvider) {
+
+        var settings = new HttpRequestCollectorSettings(
+                properties.getInclude().getUriPatterns(),
+                properties.getExclude().getUriPatterns(),
+                properties.isIncludeRequestBody(),
+                properties.isIncludeResponseBody(),
+                properties.getMaxBodyLength(),
+                properties.getExclude().getMethods(),
+                properties.getMaskable().getHeaders(),
+                properties.getMaskable().getParams()
+        );
+
+        return new HttpRequestInfoCollectorFilter(settings, httpRequestInfoCollectListenerProvider);
+    }
+
+    @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    public FilterRegistrationBean<HttpRequestInfoCollectorFilter> httpRequestInfoCollectorFilterRegistration(
+            HttpRequestInfoCollectorFilter httpRequestInfoCollectorFilter) {
+        var registration = new FilterRegistrationBean<>(httpRequestInfoCollectorFilter);
+        registration.setName("httpRequestInfoCollectorFilter");
+        registration.addUrlPatterns("/*");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+}

--- a/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoHttpExposureConfiguration.java
+++ b/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoHttpExposureConfiguration.java
@@ -1,0 +1,30 @@
+package com.sdlcpro.springlens.autoconfigure.http.request;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.exposure.http.request.HttpRequestInfoRestController;
+import com.sdlcpro.springlens.repository.http.HttpRequestInfoRepository;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
+
+import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+
+@SpringLensInternalComponent
+@Configuration(proxyBeanMethods = false)
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+@ConditionalOnWebApplication(type = Type.SERVLET)
+@ConditionalOnClass({HttpRequestInfoRestController.class})
+class HttpRequestInfoHttpExposureConfiguration {
+
+    @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    @ConditionalOnBean(HttpRequestInfoRepository.class)
+    public HttpRequestInfoRestController httpRequestInfoRestController(
+            HttpRequestInfoRepository httpRequestInfoRepository) {
+        return new HttpRequestInfoRestController(httpRequestInfoRepository);
+    }
+}

--- a/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoStorageConfiguration.java
+++ b/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoStorageConfiguration.java
@@ -1,0 +1,36 @@
+package com.sdlcpro.springlens.autoconfigure.http.request;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.repository.http.HttpRequestInfoRepository;
+import com.sdlcpro.springlens.storage.http.request.HttpRequestInfoPersistenceHandler;
+import com.sdlcpro.springlens.storage.http.request.InMemoryHttpRequestInfoRepository;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
+
+@SpringLensInternalComponent
+@Configuration(proxyBeanMethods = false)
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+@ConditionalOnClass({InMemoryHttpRequestInfoRepository.class})
+class HttpRequestInfoStorageConfiguration {
+
+    @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    @ConditionalOnMissingBean(HttpRequestInfoRepository.class)
+    public HttpRequestInfoRepository inMemoryHttpRequestInfoRepository() {
+        return new InMemoryHttpRequestInfoRepository();
+    }
+
+    @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    @ConditionalOnBean(HttpRequestInfoRepository.class)
+    @ConditionalOnMissingBean(HttpRequestInfoPersistenceHandler.class)
+    public HttpRequestInfoPersistenceHandler httpRequestInfoPersistenceHandler(
+            HttpRequestInfoRepository httpRequestInfoRepository) {
+        return new HttpRequestInfoPersistenceHandler(httpRequestInfoRepository);
+    }
+}

--- a/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/SpringLensHttpRequestInfoAutoConfiguration.java
+++ b/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/SpringLensHttpRequestInfoAutoConfiguration.java
@@ -1,0 +1,28 @@
+package com.sdlcpro.springlens.autoconfigure.http.request;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Role;
+
+@AutoConfiguration
+@SpringLensInternalComponent
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+@EnableConfigurationProperties(SpringLensHttpRequestProperties.class)
+@ConditionalOnProperty(
+        prefix = "spring.lens.http.request",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true
+)
+@Import({
+        HttpRequestInfoCollectorConfiguration.class,
+        HttpRequestInfoStorageConfiguration.class,
+        HttpRequestInfoHttpExposureConfiguration.class
+})
+public class SpringLensHttpRequestInfoAutoConfiguration {
+
+}

--- a/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/SpringLensHttpRequestProperties.java
+++ b/spring-lens-autoconfigure/src/main/java/com/sdlcpro/springlens/autoconfigure/http/request/SpringLensHttpRequestProperties.java
@@ -1,0 +1,90 @@
+package com.sdlcpro.springlens.autoconfigure.http.request;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.model.http.HttpRequestMethod;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@SpringLensInternalComponent
+@ConfigurationProperties(prefix = "spring.lens.http.request")
+public class SpringLensHttpRequestProperties {
+
+    private boolean includeRequestBody = false;
+    private boolean includeResponseBody = false;
+    private int maxBodyLength = 4096;
+    private final Include include = new Include();
+    private final Exclude exclude = new Exclude();
+    private final Maskable maskable = new Maskable();
+
+    public boolean isIncludeRequestBody() {
+        return includeRequestBody;
+    }
+
+    public void setIncludeRequestBody(boolean includeRequestBody) {
+        this.includeRequestBody = includeRequestBody;
+    }
+
+    public boolean isIncludeResponseBody() {
+        return includeResponseBody;
+    }
+
+    public void setIncludeResponseBody(boolean includeResponseBody) {
+        this.includeResponseBody = includeResponseBody;
+    }
+
+    public int getMaxBodyLength() {
+        return maxBodyLength;
+    }
+
+    public void setMaxBodyLength(int maxBodyLength) {
+        this.maxBodyLength = maxBodyLength;
+    }
+
+    public Include getInclude() {
+        return include;
+    }
+
+    public Exclude getExclude() {
+        return exclude;
+    }
+
+    public Maskable getMaskable() {
+        return maskable;
+    }
+
+    public static class Include {
+        private final Set<String> uriPatterns = new HashSet<>();
+
+        public Set<String> getUriPatterns() {
+            return uriPatterns;
+        }
+    }
+
+    public static class Exclude {
+        private final Set<String> uriPatterns = new HashSet<>(Set.of("/spring-lens/**"));
+        private final Set<HttpRequestMethod> methods = new HashSet<>();
+
+        public Set<String> getUriPatterns() {
+            return uriPatterns;
+        }
+
+        public Set<HttpRequestMethod> getMethods() {
+            return methods;
+        }
+    }
+
+    public static class Maskable {
+        private final Set<String> headers = new HashSet<>();
+        private final Set<String> params = new HashSet<>();
+
+        public Set<String> getHeaders() {
+            return headers;
+        }
+
+        public Set<String> getParams() {
+            return params;
+        }
+    }
+}

--- a/spring-lens-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-lens-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 com.sdlcpro.springlens.autoconfigure.bean.definition.SpringLensBeanDefinitionInfoAutoConfiguration
 com.sdlcpro.springlens.autoconfigure.bean.instance.SpringLensBeanInstanceInfoAutoConfiguration
 com.sdlcpro.springlens.autoconfigure.bean.condition.SpringLensConditionReportAutoConfiguration
+com.sdlcpro.springlens.autoconfigure.http.request.SpringLensHttpRequestInfoAutoConfiguration

--- a/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoCollectorConfigurationTest.java
+++ b/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoCollectorConfigurationTest.java
@@ -1,0 +1,106 @@
+package com.sdlcpro.springlens.autoconfigure.http.request;
+
+import com.sdlcpro.springlens.insight.http.request.HttpRequestInfoCollectorFilter;
+import com.sdlcpro.springlens.listener.http.request.HttpRequestInfoCollectListener;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class HttpRequestInfoCollectorConfigurationTest {
+
+    private final WebApplicationContextRunner servletRunner = new WebApplicationContextRunner()
+            .withUserConfiguration(HttpRequestInfoCollectorConfiguration.class, PropertiesConfiguration.class);
+
+    private final ApplicationContextRunner nonWebRunner = new ApplicationContextRunner()
+            .withUserConfiguration(HttpRequestInfoCollectorConfiguration.class, PropertiesConfiguration.class);
+
+    @Test
+    void registersFilterAndRegistrationByDefault() {
+        servletRunner.run(context -> {
+            assertThat(context).hasSingleBean(HttpRequestInfoCollectorConfiguration.class);
+            assertThat(context).hasSingleBean(HttpRequestInfoCollectorFilter.class);
+            assertThat(context).hasSingleBean(FilterRegistrationBean.class);
+        });
+    }
+
+    @Test
+    void registersFilterThroughAutoConfiguration() {
+        new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(SpringLensHttpRequestInfoAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).hasSingleBean(HttpRequestInfoCollectorConfiguration.class);
+                    assertThat(context).hasSingleBean(HttpRequestInfoCollectorFilter.class);
+                });
+    }
+
+    @Test
+    void backsOffInNonWebApplicationContext() {
+        nonWebRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(HttpRequestInfoCollectorConfiguration.class);
+            assertThat(context).doesNotHaveBean(HttpRequestInfoCollectorFilter.class);
+        });
+    }
+
+    @Test
+    void doesNotRegisterFilterWhenFeatureIsDisabled() {
+        new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(SpringLensHttpRequestInfoAutoConfiguration.class))
+                .withPropertyValues("spring.lens.http.request.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoCollectorConfiguration.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoCollectorFilter.class);
+                });
+    }
+
+    @Test
+    void bindsExcludeAndMaskablePropertiesUsedByFilter() {
+        servletRunner
+                .withPropertyValues(
+                        "spring.lens.http.request.exclude.uri-patterns=/health/**",
+                        "spring.lens.http.request.exclude.methods=OPTIONS",
+                        "spring.lens.http.request.maskable.headers=Authorization",
+                        "spring.lens.http.request.maskable.params=password",
+                        "spring.lens.http.request.max-body-length=2048"
+                )
+                .run(context -> {
+                    SpringLensHttpRequestProperties properties = context.getBean(SpringLensHttpRequestProperties.class);
+                    assertThat(properties.getExclude().getUriPatterns()).contains("/health/**");
+                    assertThat(properties.getMaskable().getHeaders()).containsExactly("Authorization");
+                    assertThat(properties.getMaskable().getParams()).containsExactly("password");
+                    assertThat(properties.getMaxBodyLength()).isEqualTo(2048);
+                    assertThat(context).hasSingleBean(HttpRequestInfoCollectorFilter.class);
+                });
+    }
+
+    @Test
+    void wiresListenerProviderIntoFilter() {
+        HttpRequestInfoCollectListener listener = mock(HttpRequestInfoCollectListener.class);
+
+        servletRunner
+                .withBean(HttpRequestInfoCollectListener.class, () -> listener)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(HttpRequestInfoCollectorFilter.class);
+                    assertThat(context).hasSingleBean(HttpRequestInfoCollectListener.class);
+                });
+    }
+
+    @Test
+    void collectsWithoutRegisteredListeners() {
+        servletRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(HttpRequestInfoCollectListener.class);
+            assertThat(context.getBean(HttpRequestInfoCollectorFilter.class)).isNotNull();
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(SpringLensHttpRequestProperties.class)
+    static class PropertiesConfiguration {
+    }
+}

--- a/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoHttpExposureConfigurationTest.java
+++ b/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoHttpExposureConfigurationTest.java
@@ -1,0 +1,93 @@
+package com.sdlcpro.springlens.autoconfigure.http.request;
+
+import com.sdlcpro.springlens.exposure.http.request.HttpRequestInfoRestController;
+import com.sdlcpro.springlens.repository.http.HttpRequestInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class HttpRequestInfoHttpExposureConfigurationTest {
+
+    private final WebApplicationContextRunner servletRunner = new WebApplicationContextRunner()
+            .withUserConfiguration(HttpRequestInfoHttpExposureConfiguration.class);
+
+    private final ApplicationContextRunner nonWebRunner = new ApplicationContextRunner()
+            .withUserConfiguration(HttpRequestInfoHttpExposureConfiguration.class);
+
+    private final ReactiveWebApplicationContextRunner reactiveRunner = new ReactiveWebApplicationContextRunner()
+            .withUserConfiguration(HttpRequestInfoHttpExposureConfiguration.class);
+
+    @Test
+    void registersRestControllerInServletWebApplicationWhenRepositoryIsPresent() {
+        HttpRequestInfoRepository repository = mock(HttpRequestInfoRepository.class);
+
+        servletRunner
+                .withBean(HttpRequestInfoRepository.class, () -> repository)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(HttpRequestInfoHttpExposureConfiguration.class);
+                    assertThat(context).hasSingleBean(HttpRequestInfoRestController.class);
+                });
+    }
+
+    @Test
+    void doesNotRegisterRestControllerWhenRepositoryBeanIsMissing() {
+        servletRunner.run(context -> {
+            assertThat(context).hasSingleBean(HttpRequestInfoHttpExposureConfiguration.class);
+            assertThat(context).doesNotHaveBean(HttpRequestInfoRestController.class);
+        });
+    }
+
+    @Test
+    void backsOffInNonWebApplicationContext() {
+        HttpRequestInfoRepository repository = mock(HttpRequestInfoRepository.class);
+
+        nonWebRunner
+                .withBean(HttpRequestInfoRepository.class, () -> repository)
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoHttpExposureConfiguration.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoRestController.class);
+                });
+    }
+
+    @Test
+    void backsOffInReactiveWebApplicationContext() {
+        HttpRequestInfoRepository repository = mock(HttpRequestInfoRepository.class);
+
+        reactiveRunner
+                .withBean(HttpRequestInfoRepository.class, () -> repository)
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoHttpExposureConfiguration.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoRestController.class);
+                });
+    }
+
+    @Test
+    void backsOffWhenRestControllerClassIsAbsent() {
+        HttpRequestInfoRepository repository = mock(HttpRequestInfoRepository.class);
+
+        servletRunner
+                .withClassLoader(new FilteredClassLoader(HttpRequestInfoRestController.class))
+                .withBean(HttpRequestInfoRepository.class, () -> repository)
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoHttpExposureConfiguration.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoRestController.class);
+                });
+    }
+
+    @Test
+    void doesNotRegisterExposureBeansWhenFeatureIsDisabled() {
+        new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(SpringLensHttpRequestInfoAutoConfiguration.class))
+                .withPropertyValues("spring.lens.http.request.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoHttpExposureConfiguration.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoRestController.class);
+                });
+    }
+}

--- a/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoStorageConfigurationTest.java
+++ b/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/http/request/HttpRequestInfoStorageConfigurationTest.java
@@ -1,0 +1,81 @@
+package com.sdlcpro.springlens.autoconfigure.http.request;
+
+import com.sdlcpro.springlens.repository.http.HttpRequestInfoRepository;
+import com.sdlcpro.springlens.storage.http.request.HttpRequestInfoPersistenceHandler;
+import com.sdlcpro.springlens.storage.http.request.InMemoryHttpRequestInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class HttpRequestInfoStorageConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(HttpRequestInfoStorageConfiguration.class);
+
+    @Test
+    void registersStorageBeansWhenInMemoryRepositoryClassIsPresent() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(HttpRequestInfoStorageConfiguration.class);
+            assertThat(context).hasSingleBean(HttpRequestInfoRepository.class);
+            assertThat(context).hasSingleBean(InMemoryHttpRequestInfoRepository.class);
+            assertThat(context).hasSingleBean(HttpRequestInfoPersistenceHandler.class);
+            assertThat(context.getBean(HttpRequestInfoRepository.class))
+                    .isInstanceOf(InMemoryHttpRequestInfoRepository.class);
+        });
+    }
+
+    @Test
+    void backsOffWhenInMemoryRepositoryClassIsAbsent() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(InMemoryHttpRequestInfoRepository.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoStorageConfiguration.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoRepository.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoPersistenceHandler.class);
+                });
+    }
+
+    @Test
+    void backsOffDefaultRepositoryWhenCustomRepositoryIsDefined() {
+        HttpRequestInfoRepository customRepository = mock(HttpRequestInfoRepository.class);
+
+        contextRunner
+                .withBean(HttpRequestInfoRepository.class, () -> customRepository)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(HttpRequestInfoRepository.class);
+                    assertThat(context).doesNotHaveBean(InMemoryHttpRequestInfoRepository.class);
+                    assertThat(context.getBean(HttpRequestInfoRepository.class)).isSameAs(customRepository);
+                    assertThat(context).hasSingleBean(HttpRequestInfoPersistenceHandler.class);
+                });
+    }
+
+    @Test
+    void backsOffDefaultPersistenceHandlerWhenCustomHandlerIsDefined() {
+        HttpRequestInfoRepository repository = new InMemoryHttpRequestInfoRepository();
+        HttpRequestInfoPersistenceHandler customHandler = new HttpRequestInfoPersistenceHandler(repository);
+
+        contextRunner
+                .withBean(HttpRequestInfoPersistenceHandler.class, () -> customHandler)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(HttpRequestInfoRepository.class);
+                    assertThat(context).hasSingleBean(HttpRequestInfoPersistenceHandler.class);
+                    assertThat(context.getBean(HttpRequestInfoPersistenceHandler.class)).isSameAs(customHandler);
+                });
+    }
+
+    @Test
+    void doesNotRegisterStorageBeansWhenFeatureIsDisabled() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(SpringLensHttpRequestInfoAutoConfiguration.class))
+                .withPropertyValues("spring.lens.http.request.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoStorageConfiguration.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoRepository.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoPersistenceHandler.class);
+                });
+    }
+}

--- a/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/http/request/SpringLensHttpRequestInfoAutoConfigurationTest.java
+++ b/spring-lens-autoconfigure/src/test/java/com/sdlcpro/springlens/autoconfigure/http/request/SpringLensHttpRequestInfoAutoConfigurationTest.java
@@ -1,0 +1,35 @@
+package com.sdlcpro.springlens.autoconfigure.http.request;
+
+import com.sdlcpro.springlens.exposure.http.request.HttpRequestInfoRestController;
+import com.sdlcpro.springlens.insight.http.request.HttpRequestInfoCollectorFilter;
+import com.sdlcpro.springlens.repository.http.HttpRequestInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringLensHttpRequestInfoAutoConfigurationTest {
+
+    private final WebApplicationContextRunner runner = new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(SpringLensHttpRequestInfoAutoConfiguration.class));
+
+    @Test
+    void registersFeatureBeansByDefault() {
+        runner.run(context -> {
+            assertThat(context).hasSingleBean(HttpRequestInfoRepository.class);
+            assertThat(context).hasSingleBean(HttpRequestInfoCollectorFilter.class);
+            assertThat(context).hasSingleBean(HttpRequestInfoRestController.class);
+        });
+    }
+
+    @Test
+    void disablesWhenPropertyFalse() {
+        runner.withPropertyValues("spring.lens.http.request.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoRepository.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoCollectorFilter.class);
+                    assertThat(context).doesNotHaveBean(HttpRequestInfoRestController.class);
+                });
+    }
+}

--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/listener/http/request/HttpRequestInfoCollectListener.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/listener/http/request/HttpRequestInfoCollectListener.java
@@ -1,0 +1,13 @@
+package com.sdlcpro.springlens.listener.http.request;
+
+import com.sdlcpro.springlens.model.http.request.HttpRequestInfo;
+
+@FunctionalInterface
+public interface HttpRequestInfoCollectListener {
+    /**
+     * Callback method triggered when HttpRequestInfo is collected.
+     *
+     * @param httpRequestInfo the captured HTTP request/response transaction metadata
+     */
+    void onHttpRequestInfoCollect(HttpRequestInfo httpRequestInfo);
+}

--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/request/HttpRequestInfo.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/model/http/request/HttpRequestInfo.java
@@ -11,6 +11,7 @@ import java.time.Instant;
  * unhandled exception that occurred during processing.
  */
 public record HttpRequestInfo(
+        String id,
         HttpRequestData requestData,
         HttpResponseData responseData,
         Instant startTime,
@@ -20,6 +21,7 @@ public record HttpRequestInfo(
         Throwable error) {
 
     public HttpRequestInfo {
+        Preconditions.hasText(id, "The value of id must not be blank");
         Preconditions.notNull(requestData, "HttpRequestData must not be null");
         Preconditions.notNull(responseData, "HttpResponseData must not be null");
         Preconditions.notNull(startTime, "The value of startTime must not be null");

--- a/spring-lens-core/src/main/java/com/sdlcpro/springlens/repository/http/HttpRequestInfoRepository.java
+++ b/spring-lens-core/src/main/java/com/sdlcpro/springlens/repository/http/HttpRequestInfoRepository.java
@@ -1,0 +1,12 @@
+package com.sdlcpro.springlens.repository.http;
+
+import com.sdlcpro.springlens.model.http.request.HttpRequestInfo;
+import com.sdlcpro.springlens.repository.PageableRepository;
+
+/**
+ * Repository contract for managing captured {@link HttpRequestInfo} transactions.
+ * Provides pageable, filterable access keyed by the transaction's own {@code id}.
+ */
+public interface HttpRequestInfoRepository extends PageableRepository<HttpRequestInfo, String> {
+
+}

--- a/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/request/HttpRequestInfoTest.java
+++ b/spring-lens-core/src/test/java/com/sdlcpro/springlens/model/http/request/HttpRequestInfoTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class HttpRequestInfoTest {
 
+    private static final String SAMPLE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+
     private HttpRequestData sampleRequestData() {
         return new HttpRequestData(
                 HttpRequestMethod.GET,
@@ -38,8 +40,9 @@ class HttpRequestInfoTest {
     @DisplayName("should construct successfully with valid arguments")
     void constructsSuccessfullyWithValidArguments() {
         HttpRequestInfo info = new HttpRequestInfo(
-                sampleRequestData(), sampleResponseData(), Instant.now(), 1000L, false, false, null);
+                SAMPLE_ID, sampleRequestData(), sampleResponseData(), Instant.now(), 1000L, false, false, null);
 
+        assertEquals(SAMPLE_ID, info.id());
         assertEquals(1000L, info.durationNanos());
         assertFalse(info.asyncRequest());
         assertFalse(info.asyncTimeout());
@@ -47,58 +50,72 @@ class HttpRequestInfoTest {
     }
 
     @Test
+    @DisplayName("should reject null id")
+    void rejectsNullId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new HttpRequestInfo(null, sampleRequestData(), sampleResponseData(), Instant.now(), 0, false, false, null));
+    }
+
+    @Test
+    @DisplayName("should reject blank id")
+    void rejectsBlankId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new HttpRequestInfo("   ", sampleRequestData(), sampleResponseData(), Instant.now(), 0, false, false, null));
+    }
+
+    @Test
     @DisplayName("should reject null requestData")
     void rejectsNullRequestData() {
         assertThrows(IllegalArgumentException.class,
-                () -> new HttpRequestInfo(null, sampleResponseData(), Instant.now(), 0, false, false, null));
+                () -> new HttpRequestInfo(SAMPLE_ID, null, sampleResponseData(), Instant.now(), 0, false, false, null));
     }
 
     @Test
     @DisplayName("should reject null responseData")
     void rejectsNullResponseData() {
         assertThrows(IllegalArgumentException.class,
-                () -> new HttpRequestInfo(sampleRequestData(), null, Instant.now(), 0, false, false, null));
+                () -> new HttpRequestInfo(SAMPLE_ID, sampleRequestData(), null, Instant.now(), 0, false, false, null));
     }
 
     @Test
     @DisplayName("should reject null startTime")
     void rejectsNullStartTime() {
         assertThrows(IllegalArgumentException.class,
-                () -> new HttpRequestInfo(sampleRequestData(), sampleResponseData(), null, 0, false, false, null));
+                () -> new HttpRequestInfo(SAMPLE_ID, sampleRequestData(), sampleResponseData(), null, 0, false, false, null));
     }
 
     @Test
     @DisplayName("should reject negative durationNanos")
     void rejectsNegativeDuration() {
-        assertThrows(IllegalArgumentException.class, () -> new HttpRequestInfo(sampleRequestData(),
+        assertThrows(IllegalArgumentException.class, () -> new HttpRequestInfo(SAMPLE_ID, sampleRequestData(),
                 sampleResponseData(), Instant.now(), -1, false, false, null));
     }
 
     @Test
     @DisplayName("should accept zero durationNanos")
     void acceptsZeroDuration() {
-        assertDoesNotThrow(() -> new HttpRequestInfo(sampleRequestData(), sampleResponseData(), Instant.now(), 0, false,
+        assertDoesNotThrow(() -> new HttpRequestInfo(SAMPLE_ID, sampleRequestData(), sampleResponseData(), Instant.now(), 0, false,
                 false, null));
     }
 
     @Test
     @DisplayName("should reject asyncTimeout true when asyncRequest is false")
     void rejectsAsyncTimeoutWithoutAsyncRequest() {
-        assertThrows(IllegalArgumentException.class, () -> new HttpRequestInfo(sampleRequestData(),
+        assertThrows(IllegalArgumentException.class, () -> new HttpRequestInfo(SAMPLE_ID, sampleRequestData(),
                 sampleResponseData(), Instant.now(), 0, false, true, null));
     }
 
     @Test
     @DisplayName("should accept asyncTimeout true when asyncRequest is true")
     void acceptsAsyncTimeoutWithAsyncRequest() {
-        assertDoesNotThrow(() -> new HttpRequestInfo(sampleRequestData(), sampleResponseData(), Instant.now(), 0, true,
+        assertDoesNotThrow(() -> new HttpRequestInfo(SAMPLE_ID, sampleRequestData(), sampleResponseData(), Instant.now(), 0, true,
                 true, null));
     }
 
     @Test
     @DisplayName("should accept asyncRequest true with asyncTimeout false")
     void acceptsAsyncRequestWithoutTimeout() {
-        assertDoesNotThrow(() -> new HttpRequestInfo(sampleRequestData(), sampleResponseData(), Instant.now(), 0, true,
+        assertDoesNotThrow(() -> new HttpRequestInfo(SAMPLE_ID, sampleRequestData(), sampleResponseData(), Instant.now(), 0, true,
                 false, null));
     }
 
@@ -107,7 +124,7 @@ class HttpRequestInfoTest {
     void carriesProcessingError() {
         RuntimeException error = new RuntimeException("boom");
         HttpRequestInfo info = new HttpRequestInfo(
-                sampleRequestData(), sampleResponseData(), Instant.now(), 0, false, false, error);
+                SAMPLE_ID, sampleRequestData(), sampleResponseData(), Instant.now(), 0, false, false, error);
 
         assertSame(error, info.error());
     }

--- a/spring-lens-exposure/src/main/java/com/sdlcpro/springlens/exposure/http/request/HttpRequestInfoRestController.java
+++ b/spring-lens-exposure/src/main/java/com/sdlcpro/springlens/exposure/http/request/HttpRequestInfoRestController.java
@@ -1,0 +1,101 @@
+package com.sdlcpro.springlens.exposure.http.request;
+
+import com.sdlcpro.springlens.annotation.SpringLensEndpoint;
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.exposure.ApiResponseHandler;
+import com.sdlcpro.springlens.model.http.HttpRequestMethod;
+import com.sdlcpro.springlens.model.http.request.HttpResponseStatus;
+import com.sdlcpro.springlens.query.PageRequest;
+import com.sdlcpro.springlens.query.Sort;
+import com.sdlcpro.springlens.repository.http.HttpRequestInfoRepository;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.sdlcpro.springlens.query.Filters.*;
+
+/**
+ * REST controller that exposes the HTTP request/response transactions captured by Spring Lens.
+ */
+@RestController
+@SpringLensEndpoint
+@SpringLensInternalComponent
+@RequestMapping("/spring-lens/api/http/requests")
+public class HttpRequestInfoRestController {
+    private static final int MAX_PAGE_SIZE = 1000;
+
+    private final HttpRequestInfoRepository httpRequestInfoRepository;
+
+    /**
+     * Creates a new controller backed by the given repository.
+     *
+     * @param httpRequestInfoRepository the repository holding the captured HTTP transactions;
+     *                                  must not be {@code null}
+     */
+    public HttpRequestInfoRestController(HttpRequestInfoRepository httpRequestInfoRepository) {
+        this.httpRequestInfoRepository = httpRequestInfoRepository;
+    }
+
+    /**
+     * Returns a page of captured HTTP request/response transactions.
+     *
+     * @param method     the HTTP method to filter by (e.g. GET, POST)
+     * @param uri        substring to match against the request URI
+     * @param statusCode the HTTP response status code to filter by
+     * @param clientIpAddress the client IP address to filter by
+     * @param search     free text search value applied across the request URI and client IP
+     * @param pageNumber zero-based page index (defaults to {@code 0})
+     * @param pageSize   the number of records per page (defaults to {@code 10})
+     * @param sortBy     optional property name to sort by
+     * @param sortDir    optional sort direction ({@code ASC} or {@code DESC}); defaults to
+     *                   ascending when a {@code sortBy} property is supplied
+     * @return a {@link ResponseEntity} wrapping the requested
+     * {@link com.sdlcpro.springlens.query.PageResponse page} of HTTP transactions
+     */
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getHttpRequestInfo(
+            @RequestParam(value = "method", required = false) String method,
+            @RequestParam(value = "uri", required = false) String uri,
+            @RequestParam(value = "statusCode", required = false) Integer statusCode,
+            @RequestParam(value = "clientIpAddress", required = false) String clientIpAddress,
+            @RequestParam(value = "search", required = false) String search,
+            @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
+            @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
+            @RequestParam(value = "sortBy", required = false) String sortBy,
+            @RequestParam(value = "sortDir", required = false, defaultValue = "ASC") String sortDir) {
+        var sort = sortBy == null ? Sort.unsorted() : Sort.by(sortBy, sortDir);
+        var pageRequest = new PageRequest(Math.max(pageNumber, 0), Math.min(pageSize, MAX_PAGE_SIZE), sort);
+
+        return ApiResponseHandler.handle(() -> {
+            var filter = and(
+                    eqIfPresent("requestData.method", method, HttpRequestMethod::from),
+                    containsIgnoreCaseIfPresent("requestData.uri", uri),
+                    eqIfPresent("responseData.status", statusCode, HttpResponseStatus::from),
+                    eqIfPresent("requestData.clientIpAddress", clientIpAddress),
+                    orIfPresent(
+                            search,
+                            containsIgnoreCaseIfPresent("requestData.uri", search),
+                            containsIgnoreCaseIfPresent("requestData.clientIpAddress", search)));
+
+            return this.httpRequestInfoRepository.findAll(filter, pageRequest);
+        });
+    }
+
+    /**
+     * Returns a single captured HTTP transaction by its id.
+     *
+     * @param id the transaction id
+     * @return a {@link ResponseEntity} wrapping the matching
+     * {@link com.sdlcpro.springlens.model.http.request.HttpRequestInfo}
+     */
+    @GetMapping(value = "/find", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getHttpRequestInfoById(@RequestParam("id") String id) {
+        return ApiResponseHandler.handle(
+                () -> this.httpRequestInfoRepository.findById(id),
+                "No HTTP request transaction found with id '%s'".formatted(id)
+        );
+    }
+}

--- a/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/request/HttpRequestInfoCollectorFilter.java
+++ b/spring-lens-insight/src/main/java/com/sdlcpro/springlens/insight/http/request/HttpRequestInfoCollectorFilter.java
@@ -1,0 +1,310 @@
+package com.sdlcpro.springlens.insight.http.request;
+
+import com.sdlcpro.springlens.insight.http.HttpRequestMethodMatcher;
+import com.sdlcpro.springlens.insight.http.HttpRequestMethodProvider;
+import com.sdlcpro.springlens.insight.http.HttpUriMatcher;
+import com.sdlcpro.springlens.insight.http.HttpUriProvider;
+import com.sdlcpro.springlens.insight.support.adapter.AsyncListenerAdapter;
+import com.sdlcpro.springlens.insight.trace.IdGenerator;
+import com.sdlcpro.springlens.insight.util.SafeListenerInvoker;
+import com.sdlcpro.springlens.listener.http.request.HttpRequestInfoCollectListener;
+import com.sdlcpro.springlens.matcher.CompositeMatcher;
+import com.sdlcpro.springlens.model.http.HttpRequestMethod;
+import com.sdlcpro.springlens.model.http.request.HttpHeader;
+import com.sdlcpro.springlens.model.http.request.HttpRequestData;
+import com.sdlcpro.springlens.model.http.request.HttpRequestInfo;
+import com.sdlcpro.springlens.model.http.request.HttpResponseData;
+import com.sdlcpro.springlens.model.http.request.HttpResponseStatus;
+import com.sdlcpro.springlens.time.SpringLensClock;
+import com.sdlcpro.springlens.util.Preconditions;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Servlet filter that captures an immutable {@link HttpRequestInfo} snapshot for every
+ * eligible HTTP request/response transaction and publishes it to any registered
+ * {@link HttpRequestInfoCollectListener}.
+ *
+ * <p>For asynchronously-processed requests (Spring MVC {@code DeferredResult}/{@code Callable}
+ * handlers), this filter overrides {@link #shouldNotFilterAsyncDispatch()} so that it is
+ * re-entered on the container's {@code ASYNC} re-dispatch once processing actually completes.
+ * This is deliberate: writing the buffered response body back on an {@link AsyncListenerAdapter}
+ * callback risks running after the response has already been committed by the container, so
+ * finalization (including {@link ContentCachingResponseWrapper#copyBodyToResponse()}) always
+ * happens from a dispatch cycle, not from the async listener. The listener is only used to learn
+ * whether a timeout occurred, since that fact isn't otherwise observable from the redispatch.
+ */
+public final class HttpRequestInfoCollectorFilter extends OncePerRequestFilter {
+
+    private static final String MASKED_VALUE = "***";
+    private static final String CAPTURE_STATE_ATTRIBUTE =
+            HttpRequestInfoCollectorFilter.class.getName() + ".CAPTURE_STATE";
+
+    private final HttpRequestCollectorSettings settings;
+    private final ObjectProvider<HttpRequestInfoCollectListener> listenerProvider;
+    private final CompositeMatcher<HttpRequestEligibilityContext> eligibilityMatcher;
+
+    public HttpRequestInfoCollectorFilter(
+            HttpRequestCollectorSettings settings,
+            ObjectProvider<HttpRequestInfoCollectListener> listenerProvider) {
+        Preconditions.notNull(settings, "HttpRequestCollectorSettings must not be null");
+        Preconditions.notNull(listenerProvider, "HttpRequestInfoCollectListener provider must not be null");
+        this.settings = settings;
+        this.listenerProvider = listenerProvider;
+        this.eligibilityMatcher = buildEligibilityMatcher(settings);
+    }
+
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return false;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (request.getDispatcherType() == DispatcherType.ASYNC) {
+            this.handleAsyncDispatch(request, response, filterChain);
+            return;
+        }
+
+        if (!this.isEligible(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        this.handleInitialDispatch(request, response, filterChain);
+    }
+
+    private void handleInitialDispatch(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        HttpServletRequest requestToUse = this.settings.includeRequestBody()
+                ? new ContentCachingRequestWrapper(request, this.settings.maxBodyLength())
+                : request;
+        HttpServletResponse responseToUse = this.settings.includeResponseBody()
+                ? new ContentCachingResponseWrapper(response)
+                : response;
+
+        var state = new CaptureState(
+                IdGenerator.getDefault().generateTraceId(),
+                SpringLensClock.getClock().now(),
+                SpringLensClock.nanoTime());
+        request.setAttribute(CAPTURE_STATE_ATTRIBUTE, state);
+
+        try {
+            filterChain.doFilter(requestToUse, responseToUse);
+        } catch (Throwable ex) {
+            state.asyncError = ex;
+            this.finalizeAndPublish(requestToUse, responseToUse, state, false);
+            throw ex;
+        }
+
+        if (requestToUse.isAsyncStarted()) {
+            requestToUse.getAsyncContext().addListener(new AsyncTimeoutTracker(state));
+            return;
+        }
+
+        this.finalizeAndPublish(requestToUse, responseToUse, state, false);
+    }
+
+    private void handleAsyncDispatch(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (!(request.getAttribute(CAPTURE_STATE_ATTRIBUTE) instanceof CaptureState state)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+        this.finalizeAndPublish(request, response, state, true);
+    }
+
+    private void finalizeAndPublish(
+            HttpServletRequest request, HttpServletResponse response, CaptureState state, boolean asyncRequest)
+            throws IOException {
+
+        long durationNanos = SpringLensClock.elapsedNanos(state.startNanos);
+        HttpRequestData requestData = this.buildRequestData(request);
+        HttpResponseData responseData = this.buildResponseData(response);
+
+        if (response instanceof ContentCachingResponseWrapper cachingResponse) {
+            cachingResponse.copyBodyToResponse();
+        }
+
+        var info = new HttpRequestInfo(
+                state.id,
+                requestData,
+                responseData,
+                state.startTime,
+                durationNanos,
+                asyncRequest,
+                asyncRequest && state.asyncTimeoutOccurred,
+                state.asyncError);
+
+        SafeListenerInvoker.invoke(this.listenerProvider, info, HttpRequestInfoCollectListener::onHttpRequestInfoCollect);
+    }
+
+    private HttpRequestData buildRequestData(HttpServletRequest request) {
+        HttpRequestMethod method = HttpRequestMethod.from(request.getMethod());
+        Map<String, List<String>> parameters = maskParameters(request.getParameterMap(), this.settings.maskableParams());
+        List<HttpHeader> headers = extractRequestHeaders(request, this.settings.maskableHeaders());
+        String requestBody = request instanceof ContentCachingRequestWrapper cachingRequest
+                ? this.toTruncatedString(cachingRequest.getContentAsByteArray())
+                : null;
+
+        return new HttpRequestData(
+                method,
+                request.getRequestURI(),
+                parameters,
+                request.getProtocol(),
+                request.getContentType(),
+                request.getContentLength(),
+                request.getRemoteAddr(),
+                headers,
+                requestBody);
+    }
+
+    private HttpResponseData buildResponseData(HttpServletResponse response) {
+        HttpResponseStatus status = HttpResponseStatus.from(response.getStatus());
+        List<HttpHeader> headers = extractResponseHeaders(response, this.settings.maskableHeaders());
+
+        if (response instanceof ContentCachingResponseWrapper cachingResponse) {
+            String responseBody = this.toTruncatedString(cachingResponse.getContentAsByteArray());
+            return new HttpResponseData(status, response.getContentType(), cachingResponse.getContentSize(), headers, responseBody);
+        }
+
+        return new HttpResponseData(status, response.getContentType(), 0, headers, null);
+    }
+
+    private String toTruncatedString(byte[] content) {
+        if (content == null || content.length == 0) {
+            return null;
+        }
+
+        int length = Math.min(content.length, this.settings.maxBodyLength());
+        return new String(content, 0, length, StandardCharsets.UTF_8);
+    }
+
+    private boolean isEligible(HttpServletRequest request) {
+        var context = new HttpRequestEligibilityContext(
+                request.getRequestURI(), HttpRequestMethod.from(request.getMethod()));
+        return this.eligibilityMatcher.matches(context);
+    }
+
+    private static CompositeMatcher<HttpRequestEligibilityContext> buildEligibilityMatcher(HttpRequestCollectorSettings settings) {
+        var matcher = new CompositeMatcher<HttpRequestEligibilityContext>();
+        matcher.addExcludeMatcher(new HttpUriMatcher<>(settings.excludeUriPatterns()));
+        matcher.addExcludeMatcher(new HttpRequestMethodMatcher<>(settings.excludeMethods()));
+
+        if (!settings.includeUriPatterns().isEmpty()) {
+            matcher.addIncludeMatcher(new HttpUriMatcher<>(settings.includeUriPatterns()));
+        }
+
+        return matcher;
+    }
+
+    private static List<HttpHeader> extractRequestHeaders(HttpServletRequest request, Set<String> maskableHeaders) {
+        List<HttpHeader> headers = new ArrayList<>();
+        Enumeration<String> headerNames = request.getHeaderNames();
+        if (headerNames != null) {
+            while (headerNames.hasMoreElements()) {
+                String name = headerNames.nextElement();
+                List<String> values = Collections.list(request.getHeaders(name));
+                headers.add(new HttpHeader(name, maskIfNeeded(name, values, maskableHeaders)));
+            }
+        }
+
+        return headers;
+    }
+
+    private static List<HttpHeader> extractResponseHeaders(HttpServletResponse response, Set<String> maskableHeaders) {
+        List<HttpHeader> headers = new ArrayList<>();
+        for (String name : response.getHeaderNames()) {
+            List<String> values = new ArrayList<>(response.getHeaders(name));
+            headers.add(new HttpHeader(name, maskIfNeeded(name, values, maskableHeaders)));
+        }
+
+        return headers;
+    }
+
+    private static Map<String, List<String>> maskParameters(Map<String, String[]> parameterMap, Set<String> maskableParams) {
+        Map<String, List<String>> parameters = new LinkedHashMap<>();
+        for (var entry : parameterMap.entrySet()) {
+            parameters.put(entry.getKey(), maskIfNeeded(entry.getKey(), Arrays.asList(entry.getValue()), maskableParams));
+        }
+
+        return parameters;
+    }
+
+    private static List<String> maskIfNeeded(String name, List<String> values, Set<String> maskableNames) {
+        boolean shouldMask = maskableNames.stream().anyMatch(candidate -> candidate.equalsIgnoreCase(name));
+        return shouldMask ? values.stream().map(value -> MASKED_VALUE).toList() : values;
+    }
+
+    private record HttpRequestEligibilityContext(String uri, HttpRequestMethod method)
+            implements HttpUriProvider, HttpRequestMethodProvider {
+
+        @Override
+        public String getHttpUri() {
+            return this.uri;
+        }
+
+        @Override
+        public Set<HttpRequestMethod> getHttpRequestMethods() {
+            return Set.of(this.method);
+        }
+    }
+
+    private static final class CaptureState {
+        private final String id;
+        private final Instant startTime;
+        private final long startNanos;
+        private volatile boolean asyncTimeoutOccurred;
+        private volatile Throwable asyncError;
+
+        private CaptureState(String id, Instant startTime, long startNanos) {
+            this.id = id;
+            this.startTime = startTime;
+            this.startNanos = startNanos;
+        }
+    }
+
+    private static final class AsyncTimeoutTracker implements AsyncListenerAdapter {
+        private final CaptureState state;
+
+        private AsyncTimeoutTracker(CaptureState state) {
+            this.state = state;
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) {
+            this.state.asyncTimeoutOccurred = true;
+        }
+
+        @Override
+        public void onError(AsyncEvent event) {
+            this.state.asyncError = event.getThrowable();
+        }
+    }
+}

--- a/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/request/HttpRequestInfoCollectorFilterTest.java
+++ b/spring-lens-insight/src/test/java/com/sdlcpro/springlens/insight/http/request/HttpRequestInfoCollectorFilterTest.java
@@ -1,0 +1,248 @@
+package com.sdlcpro.springlens.insight.http.request;
+
+import com.sdlcpro.springlens.listener.http.request.HttpRequestInfoCollectListener;
+import com.sdlcpro.springlens.model.http.HttpRequestMethod;
+import com.sdlcpro.springlens.model.http.request.HttpRequestInfo;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class HttpRequestInfoCollectorFilterTest {
+
+    private static HttpRequestCollectorSettings defaultSettings() {
+        return new HttpRequestCollectorSettings(
+                Set.of(), Set.of(), false, false, 1024, Set.of(), Set.of(), Set.of());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ObjectProvider<HttpRequestInfoCollectListener> providerFor(AtomicReference<HttpRequestInfo> captured) {
+        HttpRequestInfoCollectListener listener = captured::set;
+        ObjectProvider<HttpRequestInfoCollectListener> provider = mock(ObjectProvider.class);
+        when(provider.stream()).thenReturn(Stream.of(listener));
+        return provider;
+    }
+
+    @Nested
+    @DisplayName("eligibility")
+    class Eligibility {
+
+        @Test
+        @DisplayName("captures an eligible synchronous request")
+        void capturesEligibleSynchronousRequest() throws Exception {
+            var captured = new AtomicReference<HttpRequestInfo>();
+            var filter = new HttpRequestInfoCollectorFilter(defaultSettings(), providerFor(captured));
+
+            var request = new MockHttpServletRequest("GET", "/api/orders");
+            var response = new MockHttpServletResponse();
+            FilterChain chain = (req, res) -> ((MockHttpServletResponse) res).setStatus(200);
+
+            filter.doFilter(request, response, chain);
+
+            HttpRequestInfo info = captured.get();
+            assertNotNull(info);
+            assertNotNull(info.id());
+            assertFalse(info.id().isBlank());
+            assertEquals(HttpRequestMethod.GET, info.requestData().getMethod());
+            assertEquals("/api/orders", info.requestData().getUri());
+            assertEquals(200, info.responseData().getStatusCode());
+            assertFalse(info.asyncRequest());
+            assertFalse(info.asyncTimeout());
+            assertNull(info.error());
+            assertTrue(info.durationNanos() >= 0);
+        }
+
+        @Test
+        @DisplayName("skips a request matching an excluded URI pattern")
+        void skipsExcludedUriPattern() throws Exception {
+            var captured = new AtomicReference<HttpRequestInfo>();
+            var settings = new HttpRequestCollectorSettings(
+                    Set.of(), Set.of("/spring-lens/**"), false, false, 1024, Set.of(), Set.of(), Set.of());
+            var filter = new HttpRequestInfoCollectorFilter(settings, providerFor(captured));
+
+            var request = new MockHttpServletRequest("GET", "/spring-lens/ui/dashboard");
+            var response = new MockHttpServletResponse();
+            var chainInvoked = new AtomicReference<Boolean>(false);
+            FilterChain chain = (req, res) -> chainInvoked.set(true);
+
+            filter.doFilter(request, response, chain);
+
+            assertNull(captured.get());
+            assertTrue(chainInvoked.get(), "the request should still reach the rest of the chain");
+        }
+
+        @Test
+        @DisplayName("skips a request using an excluded HTTP method")
+        void skipsExcludedMethod() throws Exception {
+            var captured = new AtomicReference<HttpRequestInfo>();
+            var settings = new HttpRequestCollectorSettings(
+                    Set.of(), Set.of(), false, false, 1024, Set.of(HttpRequestMethod.OPTIONS), Set.of(), Set.of());
+            var filter = new HttpRequestInfoCollectorFilter(settings, providerFor(captured));
+
+            var request = new MockHttpServletRequest("OPTIONS", "/api/orders");
+            var response = new MockHttpServletResponse();
+            FilterChain chain = (req, res) -> ((MockHttpServletResponse) res).setStatus(204);
+
+            filter.doFilter(request, response, chain);
+
+            assertNull(captured.get());
+        }
+    }
+
+    @Nested
+    @DisplayName("masking")
+    class Masking {
+
+        @Test
+        @DisplayName("masks configured header and parameter values")
+        void masksConfiguredHeadersAndParams() throws Exception {
+            var captured = new AtomicReference<HttpRequestInfo>();
+            var settings = new HttpRequestCollectorSettings(
+                    Set.of(), Set.of(), false, false, 1024, Set.of(),
+                    Set.of("Authorization"), Set.of("password"));
+            var filter = new HttpRequestInfoCollectorFilter(settings, providerFor(captured));
+
+            var request = new MockHttpServletRequest("POST", "/api/login");
+            request.addHeader("Authorization", "Bearer secret-token");
+            request.addHeader("Accept", "application/json");
+            request.setParameter("password", "hunter2");
+            request.setParameter("username", "alice");
+            var response = new MockHttpServletResponse();
+            FilterChain chain = (req, res) -> ((MockHttpServletResponse) res).setStatus(200);
+
+            filter.doFilter(request, response, chain);
+
+            HttpRequestInfo info = captured.get();
+            assertNotNull(info);
+
+            var authHeader = info.requestData().getRequestHeaders().stream()
+                    .filter(h -> h.name().equalsIgnoreCase("Authorization"))
+                    .findFirst()
+                    .orElseThrow();
+            assertEquals(List.of("***"), authHeader.values());
+
+            var acceptHeader = info.requestData().getRequestHeaders().stream()
+                    .filter(h -> h.name().equalsIgnoreCase("Accept"))
+                    .findFirst()
+                    .orElseThrow();
+            assertEquals(List.of("application/json"), acceptHeader.values());
+
+            assertEquals(List.of("***"), info.requestData().getParameters().get("password"));
+            assertEquals(List.of("alice"), info.requestData().getParameters().get("username"));
+        }
+    }
+
+    @Nested
+    @DisplayName("body capture")
+    class BodyCapture {
+
+        @Test
+        @DisplayName("truncates a captured body beyond the configured max length")
+        void truncatesBodyBeyondMaxLength() throws Exception {
+            var captured = new AtomicReference<HttpRequestInfo>();
+            var settings = new HttpRequestCollectorSettings(
+                    Set.of(), Set.of(), true, true, 5, Set.of(), Set.of(), Set.of());
+            var filter = new HttpRequestInfoCollectorFilter(settings, providerFor(captured));
+
+            var request = new MockHttpServletRequest("POST", "/api/orders");
+            request.setContent("0123456789".getBytes(StandardCharsets.UTF_8));
+            request.setContentType("text/plain");
+            var response = new MockHttpServletResponse();
+
+            FilterChain chain = (req, res) -> {
+                req.getInputStream().readAllBytes();
+                var httpResponse = (jakarta.servlet.http.HttpServletResponse) res;
+                httpResponse.setStatus(200);
+                httpResponse.getWriter().write("responsebodylongerthanlimit");
+                httpResponse.getWriter().flush();
+            };
+
+            filter.doFilter(request, response, chain);
+
+            HttpRequestInfo info = captured.get();
+            assertNotNull(info);
+            assertEquals("01234", info.requestData().getRequestBody());
+            assertTrue(info.requestData().isBodyTruncated());
+            assertEquals("respo", info.responseData().getResponseBody());
+            assertTrue(info.responseData().isBodyTruncated());
+            assertEquals("responsebodylongerthanlimit", response.getContentAsString());
+        }
+    }
+
+    @Nested
+    @DisplayName("error handling")
+    class ErrorHandling {
+
+        @Test
+        @DisplayName("captures an unhandled exception and rethrows it")
+        void capturesUnhandledExceptionAndRethrows() {
+            var captured = new AtomicReference<HttpRequestInfo>();
+            var filter = new HttpRequestInfoCollectorFilter(defaultSettings(), providerFor(captured));
+
+            var request = new MockHttpServletRequest("GET", "/api/orders");
+            var response = new MockHttpServletResponse();
+            var failure = new IllegalStateException("boom");
+            FilterChain chain = (req, res) -> {
+                throw failure;
+            };
+
+            assertThrows(IllegalStateException.class, () -> filter.doFilter(request, response, chain));
+
+            HttpRequestInfo info = captured.get();
+            assertNotNull(info);
+            assertSame(failure, info.error());
+        }
+    }
+
+    @Nested
+    @DisplayName("async requests")
+    class AsyncRequests {
+
+        @Test
+        @DisplayName("finalizes on the async re-dispatch and records a timeout observed by the async listener")
+        void capturesAsyncCompletionWithTimeout() throws Exception {
+            var captured = new AtomicReference<HttpRequestInfo>();
+            var filter = new HttpRequestInfoCollectorFilter(defaultSettings(), providerFor(captured));
+
+            var request = new MockHttpServletRequest("GET", "/api/orders");
+            request.setAsyncSupported(true);
+            var response = new MockHttpServletResponse();
+
+            FilterChain initialChain = (req, res) -> req.startAsync();
+            filter.doFilter(request, response, initialChain);
+
+            assertNull(captured.get(), "should not publish until the async dispatch completes");
+            assertTrue(request.isAsyncStarted());
+
+            List<AsyncListener> listeners = ((org.springframework.mock.web.MockAsyncContext) request.getAsyncContext()).getListeners();
+            assertEquals(1, listeners.size());
+            listeners.get(0).onTimeout(new AsyncEvent(request.getAsyncContext()));
+
+            request.setDispatcherType(DispatcherType.ASYNC);
+            FilterChain asyncChain = (req, res) -> ((MockHttpServletResponse) res).setStatus(200);
+            filter.doFilter(request, response, asyncChain);
+
+            HttpRequestInfo info = captured.get();
+            assertNotNull(info);
+            assertTrue(info.asyncRequest());
+            assertTrue(info.asyncTimeout());
+            assertEquals(200, info.responseData().getStatusCode());
+        }
+    }
+}

--- a/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/http/request/HttpRequestInfoPersistenceHandler.java
+++ b/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/http/request/HttpRequestInfoPersistenceHandler.java
@@ -1,0 +1,33 @@
+package com.sdlcpro.springlens.storage.http.request;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.listener.http.request.HttpRequestInfoCollectListener;
+import com.sdlcpro.springlens.model.http.request.HttpRequestInfo;
+import com.sdlcpro.springlens.repository.http.HttpRequestInfoRepository;
+
+/**
+ * Persistence handler that bridges capture and storage for
+ * {@link HttpRequestInfo} transactions.
+ *
+ * <p>This component listens for captured {@link HttpRequestInfo} events
+ * via the {@link HttpRequestInfoCollectListener} callback and immediately
+ * persists them using the {@link HttpRequestInfoRepository}.</p>
+ *
+ * @since 1.0.0
+ */
+@SpringLensInternalComponent
+public class HttpRequestInfoPersistenceHandler implements HttpRequestInfoCollectListener {
+
+    private final HttpRequestInfoRepository httpRequestInfoRepository;
+
+    public HttpRequestInfoPersistenceHandler(HttpRequestInfoRepository httpRequestInfoRepository) {
+        this.httpRequestInfoRepository = httpRequestInfoRepository;
+    }
+
+    @Override
+    public void onHttpRequestInfoCollect(HttpRequestInfo httpRequestInfo) {
+        if (httpRequestInfo != null) {
+            this.httpRequestInfoRepository.save(httpRequestInfo);
+        }
+    }
+}

--- a/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/http/request/InMemoryHttpRequestInfoRepository.java
+++ b/spring-lens-storage/src/main/java/com/sdlcpro/springlens/storage/http/request/InMemoryHttpRequestInfoRepository.java
@@ -1,0 +1,71 @@
+package com.sdlcpro.springlens.storage.http.request;
+
+import com.sdlcpro.springlens.annotation.SpringLensInternalComponent;
+import com.sdlcpro.springlens.model.http.request.HttpRequestInfo;
+import com.sdlcpro.springlens.query.Filter;
+import com.sdlcpro.springlens.query.PageRequest;
+import com.sdlcpro.springlens.query.PageResponse;
+import com.sdlcpro.springlens.query.QueryExecutor;
+import com.sdlcpro.springlens.repository.http.HttpRequestInfoRepository;
+import com.sdlcpro.springlens.util.Preconditions;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * In-memory implementation of {@link HttpRequestInfoRepository}.
+ *
+ * <p>Stores {@link HttpRequestInfo} instances in a {@link ConcurrentHashMap}
+ * keyed by the transaction's own {@code id}. Paged and filtered queries
+ * delegate to {@link QueryExecutor}.</p>
+ *
+ * @since 1.0.0
+ */
+@SpringLensInternalComponent
+public class InMemoryHttpRequestInfoRepository implements HttpRequestInfoRepository {
+    private final QueryExecutor<HttpRequestInfo> queryExecutor;
+    private final ConcurrentMap<String, HttpRequestInfo> httpRequestInfoMap;
+
+    public InMemoryHttpRequestInfoRepository() {
+        this.queryExecutor = new QueryExecutor<>(HttpRequestInfo.class);
+        this.httpRequestInfoMap = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public PageResponse<HttpRequestInfo> findAll(PageRequest pageRequest) {
+        return this.findAll(Filter.UNFILTERED, pageRequest);
+    }
+
+    @Override
+    public PageResponse<HttpRequestInfo> findAll(Filter filter, PageRequest pageRequest) {
+        return this.queryExecutor.execute(this.httpRequestInfoMap.values(), filter, pageRequest);
+    }
+
+    @Override
+    public void save(HttpRequestInfo httpRequestInfo) {
+        Preconditions.notNull(httpRequestInfo, "HttpRequestInfo must not be null");
+        this.httpRequestInfoMap.put(httpRequestInfo.id(), httpRequestInfo);
+    }
+
+    @Override
+    public List<HttpRequestInfo> findAll() {
+        return List.copyOf(this.httpRequestInfoMap.values());
+    }
+
+    @Override
+    public Optional<HttpRequestInfo> findById(String id) {
+        return Optional.ofNullable(this.httpRequestInfoMap.get(id));
+    }
+
+    @Override
+    public void deleteById(String id) {
+        this.httpRequestInfoMap.remove(id);
+    }
+
+    @Override
+    public long count() {
+        return this.httpRequestInfoMap.size();
+    }
+}

--- a/spring-lens-storage/src/test/java/com/sdlcpro/springlens/storage/http/request/HttpRequestInfoPersistenceHandlerTest.java
+++ b/spring-lens-storage/src/test/java/com/sdlcpro/springlens/storage/http/request/HttpRequestInfoPersistenceHandlerTest.java
@@ -1,0 +1,51 @@
+package com.sdlcpro.springlens.storage.http.request;
+
+import com.sdlcpro.springlens.model.http.HttpRequestMethod;
+import com.sdlcpro.springlens.model.http.request.HttpRequestData;
+import com.sdlcpro.springlens.model.http.request.HttpRequestInfo;
+import com.sdlcpro.springlens.model.http.request.HttpResponseData;
+import com.sdlcpro.springlens.model.http.request.HttpResponseStatus;
+import com.sdlcpro.springlens.repository.http.HttpRequestInfoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HttpRequestInfoPersistenceHandler Tests")
+class HttpRequestInfoPersistenceHandlerTest {
+
+    @Mock
+    private HttpRequestInfoRepository httpRequestInfoRepository;
+
+    @InjectMocks
+    private HttpRequestInfoPersistenceHandler persistenceHandler;
+
+    @Test
+    @DisplayName("should save HttpRequestInfo exactly once when onHttpRequestInfoCollect is called")
+    void shouldSaveHttpRequestInfoWhenCollected() {
+        HttpRequestData requestData = new HttpRequestData(
+                HttpRequestMethod.GET, "/api/orders", Map.of(), "HTTP/1.1",
+                "application/json", 0, "127.0.0.1", List.of(), null);
+        HttpResponseData responseData = new HttpResponseData(
+                HttpResponseStatus.OK, "application/json", 0, List.of(), null);
+        HttpRequestInfo httpRequestInfo = new HttpRequestInfo(
+                "4bf92f3577b34da6a3ce929d0e0e4736", requestData, responseData, Instant.now(), 1000L,
+                false, false, null);
+
+        persistenceHandler.onHttpRequestInfoCollect(httpRequestInfo);
+
+        verify(httpRequestInfoRepository, times(1)).save(httpRequestInfo);
+        verifyNoMoreInteractions(httpRequestInfoRepository);
+    }
+}

--- a/spring-lens-storage/src/test/java/com/sdlcpro/springlens/storage/http/request/InMemoryHttpRequestInfoRepositoryTest.java
+++ b/spring-lens-storage/src/test/java/com/sdlcpro/springlens/storage/http/request/InMemoryHttpRequestInfoRepositoryTest.java
@@ -1,0 +1,103 @@
+package com.sdlcpro.springlens.storage.http.request;
+
+import com.sdlcpro.springlens.model.http.HttpRequestMethod;
+import com.sdlcpro.springlens.model.http.request.HttpRequestData;
+import com.sdlcpro.springlens.model.http.request.HttpRequestInfo;
+import com.sdlcpro.springlens.model.http.request.HttpResponseData;
+import com.sdlcpro.springlens.model.http.request.HttpResponseStatus;
+import com.sdlcpro.springlens.query.Filters;
+import com.sdlcpro.springlens.query.PageRequest;
+import com.sdlcpro.springlens.query.PageResponse;
+import com.sdlcpro.springlens.query.Sort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryHttpRequestInfoRepositoryTest {
+
+    private InMemoryHttpRequestInfoRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryHttpRequestInfoRepository();
+    }
+
+    private static HttpRequestInfo httpRequestInfo(String id, String uri) {
+        HttpRequestData requestData = new HttpRequestData(
+                HttpRequestMethod.GET, uri, Map.of(), "HTTP/1.1",
+                "application/json", 0, "127.0.0.1", List.of(), null);
+        HttpResponseData responseData = new HttpResponseData(
+                HttpResponseStatus.OK, "application/json", 0, List.of(), null);
+        return new HttpRequestInfo(id, requestData, responseData, Instant.now(), 1000L, false, false, null);
+    }
+
+    @Test
+    void saveThenFindByIdAndCount() {
+        HttpRequestInfo info = httpRequestInfo("id-1", "/api/orders");
+        repository.save(info);
+
+        assertThat(repository.count()).isEqualTo(1);
+        assertThat(repository.findById("id-1")).contains(info);
+        assertThat(repository.findAll()).containsExactly(info);
+    }
+
+    @Test
+    void saveOverwritesSameId() {
+        repository.save(httpRequestInfo("id-1", "/api/orders"));
+        HttpRequestInfo updated = httpRequestInfo("id-1", "/api/orders/updated");
+        repository.save(updated);
+
+        assertThat(repository.count()).isEqualTo(1);
+        assertThat(repository.findById("id-1")).contains(updated);
+    }
+
+    @Test
+    void deleteByIdRemovesEntry() {
+        repository.save(httpRequestInfo("id-1", "/api/orders"));
+
+        repository.deleteById("id-1");
+
+        assertThat(repository.count()).isZero();
+        assertThat(repository.findById("id-1")).isEmpty();
+    }
+
+    @Test
+    void deleteByIdIsNoOpForUnknownId() {
+        repository.save(httpRequestInfo("id-1", "/api/orders"));
+
+        repository.deleteById("does-not-exist");
+
+        assertThat(repository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void findAllWithPageRequestPaginates() {
+        repository.save(httpRequestInfo("id-1", "/api/a"));
+        repository.save(httpRequestInfo("id-2", "/api/b"));
+        repository.save(httpRequestInfo("id-3", "/api/c"));
+
+        PageRequest page0 = new PageRequest(0, 2, Sort.unsorted());
+        PageResponse<HttpRequestInfo> response = repository.findAll(page0);
+
+        assertThat(response.getTotalElements()).isEqualTo(3);
+        assertThat(response.getContent()).hasSize(2);
+    }
+
+    @Test
+    void findAllWithFilterAndPageRequest() {
+        repository.save(httpRequestInfo("id-1", "/api/keep-me"));
+        repository.save(httpRequestInfo("id-2", "/api/skip-me"));
+
+        PageRequest page = new PageRequest(0, 10, Sort.unsorted());
+        PageResponse<HttpRequestInfo> response =
+                repository.findAll(Filters.eq("id", "id-1"), page);
+
+        assertThat(response.getTotalElements()).isEqualTo(1);
+        assertThat(response.getContent()).extracting(HttpRequestInfo::id).containsExactly("id-1");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #29.

This implements Spring Lens's HTTP request/response monitoring end-to-end, following the same layered architecture already used by the Bean feature (core → insight → storage → exposure → autoconfigure). The data model for this feature (`HttpRequestInfo`, `HttpRequestData`, `HttpResponseData`, `HttpHeader`, `HttpResponseStatus`, `HttpRequestCollectorSettings`) already existed in the codebase; this PR adds the missing capture/storage/exposure pipeline.

- **`HttpRequestInfoCollectorFilter`** (`spring-lens-insight`): a servlet filter capturing method, URI, query params, headers, body (optional, size-capped), client IP, response status/headers/body, and duration for every eligible request. Eligibility filtering reuses the existing `HttpUriMatcher`/`HttpRequestMethodMatcher` infrastructure. Configured header/param values can be masked.
- **Async support**: `DeferredResult`/`Callable` handlers are tracked accurately by overriding `shouldNotFilterAsyncDispatch()` so the filter re-enters on the container's `ASYNC` re-dispatch once processing genuinely completes — finalizing (including copying the buffered response body back) from a dispatch cycle rather than an `AsyncListener` callback, since writing to the response from `onComplete` risks running after the container has already committed it. The listener is used only to observe whether a timeout occurred.
- **Storage**: `InMemoryHttpRequestInfoRepository` (unbounded `ConcurrentHashMap`, matching every existing in-memory repository in the project) + `HttpRequestInfoPersistenceHandler` bridging the collection listener to the repository.
- **Exposure**: `HttpRequestInfoRestController` at `/spring-lens/api/http/requests` — paged/filtered listing (method, uri, statusCode, clientIpAddress, free-text search) plus find-by-id.
- **Autoconfigure**: the standard `Collector/Storage/HttpExposure/Umbrella` four-class split, gated by `spring.lens.http.request.enabled` (default `true`). `spring.lens.http.request.exclude.uri-patterns` defaults to `/spring-lens/**` so the tool doesn't monitor its own dashboard/API traffic.

One model change: `HttpRequestInfo` gained a required `id` field (populated via the existing `RandomIdGenerator.generateTraceId()`), since the `Repository<T, ID>` contract needs every entity to carry its own identity and this record had no natural key.

No new dependencies were added — everything used was already declared (`jakarta.servlet-api`, `spring-web`, `spring-webmvc` were already compile deps of `spring-lens-insight`; `spring-test`'s `MockHttpServletRequest`/`MockFilterChain` come from the root `spring-boot-starter-test` test dependency already inherited by every module).

### Known scope notes / possible follow-ups
- In-memory storage is intentionally unbounded for now, matching every existing repository in the project (`InMemoryBeanDefinitionInfoRepository`, etc.) — bounding/eviction would be a good separate follow-up given HTTP request volume is unlike the one-time bean-definition scan.
- No aggregate `/summary` endpoint, since issue #29 didn't call for one (unlike the Bean feature).
- No dedicated REST controller unit test, matching the existing gap on `BeanDefinitionInfoRestController` (only indirectly exercised via autoconfigure tests today).

## Test plan

- [x] `mvn test` passes across all modules (core, insight, storage, exposure, autoconfigure)
- [x] `mvn verify` passes (including the failsafe integration-test/verify goals already configured per module)
- [x] New unit tests added: `HttpRequestInfoCollectorFilterTest` (eligibility, header/param masking, body truncation, exception capture, async completion + timeout), `InMemoryHttpRequestInfoRepositoryTest`, `HttpRequestInfoPersistenceHandlerTest`, and four autoconfigure tests (`HttpRequestInfoCollectorConfigurationTest`, `HttpRequestInfoStorageConfigurationTest`, `HttpRequestInfoHttpExposureConfigurationTest`, `SpringLensHttpRequestInfoAutoConfigurationTest`) mirroring the existing Bean feature's test conventions
- [x] Existing `HttpRequestInfoTest` updated for the new `id` field